### PR TITLE
Fix status parsing and PSK comparison

### DIFF
--- a/src/files/usr/bin/check_chisel.sh
+++ b/src/files/usr/bin/check_chisel.sh
@@ -17,7 +17,7 @@ while IFS= read -r line; do
 
     if [ ! -z "$HAS_CONNECTED" ]; then
         last_status="Connected"
-    elif [ ! -z "$HAS_CONNECTED" ]; then
+    elif [ ! -z "$HAS_CONNECTING" ]; then
         last_status="Connecting"
     else
         last_status="other"

--- a/src/files/usr/bin/wg_prepare_config.sh
+++ b/src/files/usr/bin/wg_prepare_config.sh
@@ -39,7 +39,7 @@ uci set network.wgclient.public_key=${WG_PUB}
 uci set network.wgclient.route_allowed_ips="0"
 uci set network.wgclient.endpoint_host=${WG_SERV}
 uci set network.wgclient.endpoint_port=${WG_PORT}
-if [ "$WG_PSK" -ne "null" ];then
+if [ "$WG_PSK" != "null" ]; then
     uci set network.wgclient.preshared_key="${WG_PSK}"
 fi
 uci set network.wgclient.persistent_keepalive="25"


### PR DESCRIPTION
## Summary
- fix typo in `check_chisel.sh` when detecting 'Connecting'
- compare PresharedKey string properly in `wg_prepare_config.sh`

## Testing
- `bash -n src/files/usr/bin/wg_prepare_config.sh`
- `bash -n src/files/usr/bin/check_chisel.sh`


------
https://chatgpt.com/codex/tasks/task_b_685b0c1ef63c832f96fa696e5215e6b3