### PR TITLE
Fix variable name in wifi check script

### DIFF
--- a/src/files/usr/bin/wrong_wifi_pass_checker.sh
+++ b/src/files/usr/bin/wrong_wifi_pass_checker.sh
@@ -34,7 +34,7 @@ check() {
 
         IP=$(ifconfig $interface | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}')
 
-        counterfile="/tmp/$device.value"
+        counterfile="/tmp/${interface}.value"
         if [ -z "$IP" ]; then
             echo $interface has not ip
             if [ ! -f "$counterfile" ]; then


### PR DESCRIPTION
## Summary
- ensure wrong_wifi_pass_checker uses the `interface` parameter

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_685c4379915c832fa91ddf5c482efee8