### PR TITLE
Add tests for config-generator isValidId

### DIFF
--- a/config-generator/index.js
+++ b/config-generator/index.js
@@ -53,9 +53,11 @@ const server = http.createServer(async (req, res) => {
 });
 
 // Start the server on port 8080
-server.listen(8080, () => {
-  console.log('Server listening on port 8080');
-});
+if (require.main === module) {
+  server.listen(8080, () => {
+    console.log('Server listening on port 8080');
+  });
+}
 
 /**
  * Validate the 'id' format (MD5 hash of a MAC address).
@@ -111,3 +113,5 @@ function sendResponse(res, statusCode, message, contentType = 'text/plain') {
   res.setHeader('Content-Type', contentType);
   res.end(message);
 }
+
+module.exports = { isValidId };

--- a/config-generator/index.test.js
+++ b/config-generator/index.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const { isValidId } = require('./index');
+
+// Valid 32-character hex string
+assert.strictEqual(
+  isValidId('0123456789abcdef0123456789abcdef'),
+  true,
+  'Expected valid ID to return true'
+);
+
+// Invalid: too short
+assert.strictEqual(
+  isValidId('0123456789abcdef0123456789abcde'),
+  false,
+  'Expected short ID to return false'
+);
+
+// Invalid: contains non-hex characters
+assert.strictEqual(
+  isValidId('0123456789abcdef0123456789abcdeg'),
+  false,
+  'Expected non-hex ID to return false'
+);
+
+// Invalid: undefined value
+assert.strictEqual(
+  isValidId(undefined),
+  false,
+  'Expected undefined ID to return false'
+);
+
+console.log('All tests passed.');

--- a/config-generator/package.json
+++ b/config-generator/package.json
@@ -4,7 +4,7 @@
   "description": "Return the wireguard peer.conf from s3",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node index.test.js"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
## Summary
- prevent server from automatically starting when imported
- export `isValidId` for testing
- add `index.test.js` with basic tests
- update npm test script to run tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685c488f3b90832f84cfb50b05f8c594