### PR TITLE
Add link check page

### DIFF
--- a/src/files/usr/bin/check_link.sh
+++ b/src/files/usr/bin/check_link.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+STARLINK_IF="wwan"
+IRAN_IF="wan"
+CITY_IF="wan2"
+
+link="$1"
+host="$2"
+
+case "$link" in
+    starlink)
+        iface="$STARLINK_IF"
+        [ -z "$host" ] && host="8.8.8.8"
+        ;;
+    iran)
+        iface="$IRAN_IF"
+        [ -z "$host" ] && host="5.52.0.1"
+        ;;
+    citylink)
+        iface="$CITY_IF"
+        [ -z "$host" ] && host="5.52.0.1"
+        ;;
+    vpn)
+        status=$(sh /usr/bin/wg_scripts.sh status)
+        echo "$status" | grep '__Connected__' >/dev/null 2>&1 && { echo "OK"; exit 0; }
+        echo "FAIL"; exit 0
+        ;;
+    *)
+        echo "UNKNOWN"
+        exit 1
+        ;;
+esac
+
+if ping -I "$iface" -c1 -W2 "$host" >/dev/null 2>&1; then
+    echo "OK"
+else
+    echo "FAIL"
+fi

--- a/src/files/usr/bin/dragon.sh
+++ b/src/files/usr/bin/dragon.sh
@@ -350,3 +350,8 @@ if [ "$1" = "monitor-log" ]; then
         response "No log"
     fi
 fi
+
+if [ "$1" == "check-link" ];then
+    result=$(sh /usr/bin/check_link.sh "$2" "$3")
+    response "$result"
+fi

--- a/src/files/www/dashboard/check.html
+++ b/src/files/www/dashboard/check.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <title>Link Check</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel="stylesheet" href="styles/style.css">
+    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
+    <script type="text/javascript" src="scripts/common/loading.js" defer></script>
+    <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
+    <script type="text/javascript" src="scripts/page-specific/check.js" defer></script>
+</head>
+<body>
+<div class="container mt-3">
+    <a id="back-btn-href" class="btn btn-outline-secondary mb-3" href="dashboard.html">Back to Dashboard</a>
+
+    <div class="mb-3">
+        <label class="form-label">Starlink Host/IP</label>
+        <div class="input-group">
+            <input type="text" class="form-control" id="starlink-host" placeholder="8.8.8.8">
+            <button class="btn btn-primary" id="starlink-check">Check</button>
+        </div>
+        <div id="starlink-result" class="mt-1"></div>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Iran Host/IP</label>
+        <div class="input-group">
+            <input type="text" class="form-control" id="iran-host" placeholder="5.52.0.1">
+            <button class="btn btn-primary" id="iran-check">Check</button>
+        </div>
+        <div id="iran-result" class="mt-1"></div>
+    </div>
+
+    <div class="mb-3">
+        <button class="btn btn-secondary" id="vpn-check">Check VPN</button>
+        <span id="vpn-result" class="ms-2"></span>
+    </div>
+
+    <div class="mb-3">
+        <button class="btn btn-secondary" id="city-check">Check CityLink</button>
+        <span id="city-result" class="ms-2"></span>
+    </div>
+</div>
+
+<div id="overlay" class="display=none flex-column align-items-center mb-3">
+    <div class="spinner-border text-light mb-2" role="status">
+        <span class="visually-hidden">Loading...</span>
+    </div>
+    <div class="fs-4 px-4 py-3" role="message">
+        <h6 id="overlay_message" class="text text-light">Loading...</h6>
+    </div>
+</div>
+</body>
+</html>

--- a/src/files/www/dashboard/dashboard.html
+++ b/src/files/www/dashboard/dashboard.html
@@ -110,6 +110,15 @@
                     <span class="d-none d-sm-inline">Connection Logs</span>
                 </button>
             </div>
+            <div class="row mt-3">
+                <button id="check-btn" type="button" class="btn btn-secondary text-start">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-activity" viewBox="0 0 16 16">
+                        <path fill-rule="evenodd" d="M0 8a.5.5 0 0 1 .5-.5h2.707l2-4A.5.5 0 0 1 5.5 3h.001a.5.5 0 0 1 .462.308L8.147 8.5H11.5a.5.5 0 0 1 .45.725l-2 4a.5.5 0 0 1-.9-.005L7.186 9.5H3.854l-1.5 3A.5.5 0 0 1 1.9 13H.5a.5.5 0 0 1-.5-.5V8z"/>
+                    </svg>
+                    <span class="d-inline d-sm-none small">Check</span>
+                    <span class="d-none d-sm-inline">Check Links</span>
+                </button>
+            </div>
         </div>
 
         <div class="col">

--- a/src/files/www/dashboard/scripts/page-specific/check.js
+++ b/src/files/www/dashboard/scripts/page-specific/check.js
@@ -1,0 +1,40 @@
+const starHost = document.getElementById('starlink-host');
+const starBtn = document.getElementById('starlink-check');
+const starRes = document.getElementById('starlink-result');
+
+const iranHost = document.getElementById('iran-host');
+const iranBtn = document.getElementById('iran-check');
+const iranRes = document.getElementById('iran-result');
+
+const vpnBtn = document.getElementById('vpn-check');
+const vpnRes = document.getElementById('vpn-result');
+
+const cityBtn = document.getElementById('city-check');
+const cityRes = document.getElementById('city-result');
+
+async function check(link, host, resElem){
+    loading(true, 'Checking...');
+    let cmd = 'check-link ' + link;
+    if(host){
+        cmd += ' ' + host;
+    }
+    const result = await async_lua_call('dragon.sh', cmd);
+    resElem.textContent = result.trim();
+    loading(false);
+}
+
+starBtn.addEventListener('click', ()=>{
+    check('starlink', starHost.value || '8.8.8.8', starRes);
+});
+
+iranBtn.addEventListener('click', ()=>{
+    check('iran', iranHost.value || '5.52.0.1', iranRes);
+});
+
+vpnBtn.addEventListener('click', ()=>{
+    check('vpn', '', vpnRes);
+});
+
+cityBtn.addEventListener('click', ()=>{
+    check('citylink', '', cityRes);
+});

--- a/src/files/www/dashboard/scripts/page-specific/dashboard.js
+++ b/src/files/www/dashboard/scripts/page-specific/dashboard.js
@@ -13,6 +13,7 @@ const btnGuest = document.getElementById('guest-btn')
 const btnReach = document.getElementById('reach-btn')
 const btnFirmware = document.getElementById('firmware-btn')
 const btnLogs = document.getElementById('logs-btn')
+const btnCheck = document.getElementById('check-btn')
 
 btnStarlink.onclick=function (e){
     window.location.href = "wifi.html?ref=dashboard";
@@ -37,6 +38,9 @@ btnFirmware.onclick=function (e){
 }
 btnLogs.onclick=function (e){
     window.location.href = "logs.html?ref=dashboard";
+}
+btnCheck.onclick=function(e){
+    window.location.href = "check.html?ref=dashboard";
 }
 
 


### PR DESCRIPTION
## Summary
- add `check_link.sh` script for pinging links
- expose new `check-link` command via `dragon.sh`
- create a Connectivity Check page
- add JS to call backend and show results
- link new page from the dashboard

## Testing
- `npm test` in `config-generator`
- `npm test` failed in `server/chisel_config_manager` (no test script)

------
https://chatgpt.com/codex/tasks/task_b_685c5f7cdc88832fb5490652f3b5f89e