### PR TITLE
Allow custom update URL

### DIFF
--- a/src/files/usr/bin/router_updater.sh
+++ b/src/files/usr/bin/router_updater.sh
@@ -4,7 +4,7 @@
 deviceModel=$(cat /proc/device-tree/model)
 deviceModel=$(echo "$deviceModel" | awk '{print tolower($0)}' | tr ' ' '_')
 
-github_api_url=https://api.github.com/repos/nasnet-community/neighbor-link/releases/latest
+github_api_url=${2:-https://api.github.com/repos/nasnet-community/neighbor-link/releases/latest}
 
 json_response=$(curl -s "$github_api_url")
 

--- a/src/files/www/dashboard/firmware.html
+++ b/src/files/www/dashboard/firmware.html
@@ -52,6 +52,9 @@
     
         <div id="upgrade-part" class="" data-bs-parent="#myAccordion">
             <div class="container">
+                <div class="row justify-content-center mb-2">
+                    <input type="text" id="update-url" class="form-control" style="max-width: 500px;" value="https://api.github.com/repos/nasnet-community/neighbor-link/releases/latest">
+                </div>
                 <div class="row d-flex justify-content-center mb-3 mt-3">
                     <button type="button" class="col-auto btn btn-primary" id="check-update" >
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-repeat" viewBox="0 0 16 16">

--- a/src/files/www/dashboard/scripts/page-specific/firmware.js
+++ b/src/files/www/dashboard/scripts/page-specific/firmware.js
@@ -1,9 +1,10 @@
 var checkUpdateButton = document.getElementById('check-update');
 var doUpdateButton = document.getElementById("do-update")
+var updateUrlInput = document.getElementById("update-url")
 
 checkUpdateButton.onclick = function(e){
     loading(true,"Checking for update")
-    const UPDATE_CHECK=["file","exec",{"command":"router_updater.sh","params":[ "Check" ]}];
+    const UPDATE_CHECK=["file","exec",{"command":"router_updater.sh","params":[ "Check", updateUrlInput.value ]}];
     ubus_call(UPDATE_CHECK,function(chunk){
         loading(false)
         if(chunk.length > 1){
@@ -27,7 +28,7 @@ checkUpdateButton.onclick = function(e){
 }
 
 doUpdateButton.onclick = function(e){
-    const UPDATE_DO=["file","exec",{"command":"router_updater.sh","params":[ "Do" ]}];
+    const UPDATE_DO=["file","exec",{"command":"router_updater.sh","params":[ "Do", updateUrlInput.value ]}];
     const SYSUPGRADE_N=["file","exec",{"command":"router_updater.sh","params":[ "Upgrade" ]}];
     loading(true,"Preparing for upgrade")
     ubus_call(UPDATE_DO,function(chunk){


### PR DESCRIPTION
## Summary
- let `router_updater.sh` accept a custom release URL
- add an input on `firmware.html` to change the update source
- pass that value in `firmware.js` when checking for updates

## Testing
- `npm test` in `config-generator`
- `npm test` in `server/chisel_config_manager` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685d17004370832fb6df346a141a4b2a