### PR TITLE
Add log viewer titles and enrich log files

### DIFF
--- a/src/files/usr/bin/link_monitor.sh
+++ b/src/files/usr/bin/link_monitor.sh
@@ -17,20 +17,21 @@ check_iface(){
     host=$2
     file=$3
     if ping -I "$iface" -c1 -W2 "$host" >/dev/null 2>&1; then
-        echo "$(date +"%F %T") OK" >> "$file"
+        echo "$(date +"%F %T") [$host] OK" >> "$file"
     else
-        echo "$(date +"%F %T") FAIL" >> "$file"
+        echo "$(date +"%F %T") [$host] FAIL" >> "$file"
     fi
+    tail -n 1000 "$file" > "$file.tmp" && mv "$file.tmp" "$file"
 }
 
 check_vpn(){
     status=$(sh /usr/bin/wg_scripts.sh status)
-    echo "$status" | grep '__Connected__' >/dev/null 2>&1
-    if [ $? -eq 0 ]; then
-        echo "$(date +"%F %T") OK" >> "$VPN_LOG"
+    if echo "$status" | grep '__Connected__' >/dev/null 2>&1; then
+        echo "$(date +"%F %T") [vpn] OK" >> "$VPN_LOG"
     else
-        echo "$(date +"%F %T") FAIL" >> "$VPN_LOG"
+        echo "$(date +"%F %T") [vpn] FAIL" >> "$VPN_LOG"
     fi
+    tail -n 1000 "$VPN_LOG" > "$VPN_LOG.tmp" && mv "$VPN_LOG.tmp" "$VPN_LOG"
 }
 
 while true; do

--- a/src/files/www/dashboard/logs.html
+++ b/src/files/www/dashboard/logs.html
@@ -20,6 +20,7 @@
         <button class="btn btn-secondary" data-type="vpn">VPN</button>
         <button class="btn btn-secondary" data-type="citylink">CityLink</button>
     </div>
+    <h6 id="log-title" class="mb-2">Starlink Log</h6>
     <pre id="log-content" class="bg-body-secondary p-2" style="height:60vh; overflow:auto;"></pre>
 </div>
 <div id="overlay" class="display=none flex-column align-items-center mb-3">

--- a/src/files/www/dashboard/scripts/page-specific/logs.js
+++ b/src/files/www/dashboard/scripts/page-specific/logs.js
@@ -1,4 +1,5 @@
 const container = document.getElementById('log-content');
+const title = document.getElementById('log-title');
 const buttons = document.querySelectorAll('[data-type]');
 
 function loadLogs(type){
@@ -6,6 +7,10 @@ function loadLogs(type){
     const CMD=["file","exec",{"command":"dragon.sh","params":["monitor-log", type]}];
     async_ubus_call(CMD).then(res => {
         container.textContent = res[1].stdout || '';
+        if (title) {
+            const label = type.charAt(0).toUpperCase() + type.slice(1);
+            title.textContent = `${label} Log`;
+        }
         loading(false);
     });
 }


### PR DESCRIPTION
## Summary
- show which log is displayed on logs page
- include host or service name in link monitor logs
- rotate logs to keep last 1000 lines

## Testing
- `shellcheck src/files/usr/bin/link_monitor.sh`

------
https://chatgpt.com/codex/tasks/task_b_685d20e53e68832f9a9607f998d22159