### PR TITLE
Show device limits on management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ The solution includes integrating a cloud server, empowering users to create per
 
 ## User Management Enhancements
 Users can limit the number of devices per account using the **Max Devices** field and optionally set a comma separated list of permitted MAC addresses. A helper script `user_stats.sh` prints traffic usage per user based on firewall counters.
+The management page table now lists these values beside each username so administrators can quickly review configured limits.

--- a/src/files/www/dashboard/management.html
+++ b/src/files/www/dashboard/management.html
@@ -49,6 +49,8 @@
                         <tr>
                             <th scope="col">#</th>
                             <th scope="col">Username</th>
+                            <th scope="col">Max Devices</th>
+                            <th scope="col">Allowed MACs</th>
                             <th scope="col">Actions</th>
                         </tr>
                     </thead>

--- a/src/files/www/dashboard/scripts/page-specific/management.js
+++ b/src/files/www/dashboard/scripts/page-specific/management.js
@@ -103,8 +103,10 @@ function renderUserList() {
     users.forEach((user, index) => {
         const row = document.createElement('tr');
         row.innerHTML = `
-            <td>${index+1}</td>
+            <td>${index + 1}</td>
             <td>${user.username}</td>
+            <td>${user.max ? user.max : 'No limit'}</td>
+            <td>${user.macs ? user.macs : 'Any'}</td>
             <td>
                 <button onclick="editUser('${user.username}')" type="button" class="btn btn-primary">Edit</button>
                 <button onclick="deleteUserModal('${user.username}')" type="button" class="btn btn-danger">Delete</button>


### PR DESCRIPTION
## Summary
- show Max Devices and Allowed MACs in management table
- display 'No limit' or 'Any' when fields are blank
- document the new view in README

## Testing
- `npm test --prefix config-generator`

------
https://chatgpt.com/codex/tasks/task_b_685d361e6c6c832f8d81964ade07c199