### PR TITLE
Fix version label placement

### DIFF
--- a/src/files/www/dashboard/dashboard.html
+++ b/src/files/www/dashboard/dashboard.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" src="scripts/common/heartBeat.js" defer></script>
 </head>
 
-<body class="d-flex justify-content-center align-items-center">
+<body class="d-flex flex-column justify-content-center align-items-center">
     <div class="container row align-items-center justify-content-center text-center min-vh-100 px-1">
         <div class="col-auto mx-3">
             <div class="row mt-3">


### PR DESCRIPTION
## Summary
- ensure the body uses a column flex layout so the build-version text displays below the VPN section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685d5e92ac98832f9a4056f5d43e1fc5