### PR TITLE
Fix portal server directory listing

### DIFF
--- a/src/files/etc/config/uhttpd
+++ b/src/files/etc/config/uhttpd
@@ -22,3 +22,6 @@ config uhttpd 'portal'
         option network_timeout '30'
         option http_keepalive '20'
         option tcp_keepalive '1'
+list index_page "splash.html"
+option no_dirlists "1"
+


### PR DESCRIPTION
## Summary
- configure uhttpd portal instance to disable directory listing
- set `splash.html` as default index page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685d5eab0d70832f90cfabb90e91a63b