### PR TITLE
Reposition build version in dashboard

### DIFF
--- a/src/files/www/dashboard/dashboard.html
+++ b/src/files/www/dashboard/dashboard.html
@@ -197,12 +197,13 @@
                     </div>
                 </div>
 
+                <div class="text-center my-3">
+                    <small id="build-version"></small>
+                </div>
+
             </div>
 
         </div>
-    </div>
-    <div class="text-center my-3">
-        <small id="build-version"></small>
     </div>
     <div id="overlay" class="display=none flex-column align-items-center mb-3">
         <div class="spinner-border text-light mb-2" role="status">


### PR DESCRIPTION
## Summary
- move the build version text inside the main content area so it appears below the warning section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685d7a1b64d4832facfedecef16bba42