### PR TITLE
Fix interface selection for connectivity checks

### DIFF
--- a/src/files/usr/bin/check_link.sh
+++ b/src/files/usr/bin/check_link.sh
@@ -39,6 +39,10 @@ case "$link" in
         ;;
 esac
 
+# Determine the actual network device for the interface
+device=$(ifstatus "$iface" 2>/dev/null | jq -r '.device // .l3_device')
+[ -n "$device" ] && [ "$device" != "null" ] && iface="$device"
+
 if ping -I "$iface" -c1 -W2 "$host" >/dev/null 2>&1; then
     printf '%b\n' "${GREEN}OK${NC}"
 else

--- a/src/files/usr/bin/link_monitor.sh
+++ b/src/files/usr/bin/link_monitor.sh
@@ -16,6 +16,8 @@ check_iface(){
     iface=$1
     host=$2
     file=$3
+    device=$(ifstatus "$iface" 2>/dev/null | jq -r '.device // .l3_device')
+    [ -n "$device" ] && [ "$device" != "null" ] && iface="$device"
     if ping -I "$iface" -c1 -W2 "$host" >/dev/null 2>&1; then
         echo "$(date +"%F %T") [$host] OK" >> "$file"
     else


### PR DESCRIPTION
## Summary
- ensure check_link.sh resolves actual device using `ifstatus`
- update link_monitor.sh to route pings through resolved devices

## Testing
- `npm test --prefix config-generator`

------
https://chatgpt.com/codex/tasks/task_b_685d92504fc4832f9a7af93b09705c88