### PR TITLE
Check client string before retrieval

### DIFF
--- a/server/Iran_server/Iran_server_setup.sh
+++ b/server/Iran_server/Iran_server_setup.sh
@@ -286,6 +286,12 @@ deploy_service() {
 retrieve_service_config() {
     # Implement logic to retrieve active service config
     echo "Retrieving active service config..."
+
+    if [[ ! -f /etc/chisel/clients/client.str ]]; then
+        echo "Warning: /etc/chisel/clients/client.str not found" >&2
+        exit 1
+    fi
+
     KEYSTRING=$(cat /etc/chisel/clients/client.str)
 
     echo ""


### PR DESCRIPTION
## Summary
- validate the client string file before printing config

## Testing
- `shellcheck server/Iran_server/Iran_server_setup.sh`

------
https://chatgpt.com/codex/tasks/task_b_685ea41833d8832fb0e089622b311bfb