### PR TITLE
Fix duplicate module export

### DIFF
--- a/config-generator/index.js
+++ b/config-generator/index.js
@@ -68,7 +68,6 @@ function isValidId(id) {
   return /^[a-fA-F0-9]{32}$/.test(id);
 }
 
-module.exports = { isValidId };
 
 /**
  * Check if a file exists.


### PR DESCRIPTION
## Summary
- drop intermediate `module.exports` so `isValidId` is exported only once

## Testing
- `node config-generator/index.test.js`

------
https://chatgpt.com/codex/tasks/task_b_685efcea5c28832fb4c2d8e985967b90