### PR TITLE
Fix typos in dashboard scripts

### DIFF
--- a/src/files/www/dashboard/scripts/page-specific/citylink.js
+++ b/src/files/www/dashboard/scripts/page-specific/citylink.js
@@ -19,7 +19,7 @@ connectButton.onclick = async function(e){
         // connectButton.classList.add("btn-success")
     }
     else{
-        addCustomAlert("Somthing Went Wrong","Please try Agaign",6000)
+        addCustomAlert("Something Went Wrong","Please try Again",6000)
     }
     showLoadingConnectButton(false)
 }
@@ -33,7 +33,7 @@ disconnectButton.onclick = async function(e){
         loading(false);
         return;
     }
-    addCustomAlert("Something Went Wrong", "Please make sure your iran internet is working and try agaign",5000)
+    addCustomAlert("Something Went Wrong", "Please make sure your iran internet is working and try again",5000)
     loading(false);
     
 }

--- a/src/files/www/dashboard/scripts/page-specific/outline.js
+++ b/src/files/www/dashboard/scripts/page-specific/outline.js
@@ -61,7 +61,7 @@ convertButton.onclick = async function(e){
     if( parsedKey["type"] == "Domain" ){
         outlineServerIP=await domainToIP(parsedKey["host"])
         if (  outlineServerIP == null ){
-            addCustomAlert("Invarlid outline server","The domain is not resolve to any ipv4")
+            addCustomAlert("Invalid outline server","The domain is not resolve to any ipv4")
             loading(false)
             return;
         }


### PR DESCRIPTION
## Summary
- correct typo messages in citylink.js
- fix outline server error message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685efcede328832f93cb63193b867932