### PR TITLE
Fix argument check typo

### DIFF
--- a/src/files/usr/bin/dragon.sh
+++ b/src/files/usr/bin/dragon.sh
@@ -174,7 +174,7 @@ fi
 
 if [ "$1" == "infinite-reach-connect" ];then
 
-    if [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ] || [ -z "$35" ] || [ -z "$6" ] || [ -z "$7" ] || [ -z "$8" ] || [ -z "$9" ]; then
+    if [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ] || [ -z "$5" ] || [ -z "$6" ] || [ -z "$7" ] || [ -z "$8" ] || [ -z "$9" ]; then
         response "Missing_Info"
         exit 1
     fi


### PR DESCRIPTION
## Summary
- correct parameter validation for `infinite-reach-connect`

## Testing
- `shellcheck src/files/usr/bin/dragon.sh`

------
https://chatgpt.com/codex/tasks/task_b_685f07152408832f9689d9b2f1a5dd3d