### PR TITLE
Fix missing log file case in chisel status script

### DIFF
--- a/src/files/usr/bin/check_chisel.sh
+++ b/src/files/usr/bin/check_chisel.sh
@@ -7,6 +7,12 @@ if [ "$1" == "outline" ];then
     LOGFILE=/var/log/outline-gate.log
 fi
 
+# Exit early if the log file hasn't been created yet
+if [ ! -f "$LOGFILE" ]; then
+    echo "unknown"
+    exit 0
+fi
+
 # Filter log lines containing "Connect" (case-insensitive)
 last_status=""
 # Use a while loop to read each line from the grep output


### PR DESCRIPTION
## Summary
- handle absent log files in `check_chisel.sh`
- exit early with `unknown` when log not found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f0846617c832fa3a99ffcc8946b6b