### PR TITLE
Improve architecture detection for proxymaster

### DIFF
--- a/src/files/usr/bin/proxymaster.sh
+++ b/src/files/usr/bin/proxymaster.sh
@@ -1,8 +1,39 @@
 #!/bin/sh
 # Define the file name and the URL to download from
 FILE="/tmp/chisel"
-# TODO : Some arch is not compatible with this
-ARCH=$(uname -m)
+# Determine architecture for chisel download
+ARCH_RAW=$(uname -m)
+case "$ARCH_RAW" in
+    x86_64)
+        ARCH="amd64"
+        ;;
+    i386|i486|i586|i686)
+        ARCH="386"
+        ;;
+    aarch64*|arm64*)
+        ARCH="arm64"
+        ;;
+    armv7l|armv6l|armv5l|arm*)
+        ARCH="arm"
+        ;;
+    mips64el)
+        ARCH="mips64le"
+        ;;
+    mips64)
+        ARCH="mips64"
+        ;;
+    mipsel)
+        ARCH="mipsle"
+        ;;
+    mips)
+        ARCH="mips"
+        ;;
+    *)
+        logger -t pmaster "Unsupported architecture: $ARCH_RAW"
+        exit 1
+        ;;
+esac
+
 URL="https://holistic-config.s3.us-west-1.amazonaws.com/chisel/chisel_1.10.0_linux_${ARCH}_softfloat"
 
 reverse_string() {


### PR DESCRIPTION
## Summary
- map `uname -m` to chisel build names in `proxymaster.sh`
- log an explicit error and exit when architecture isn't supported

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f0f28e238832fb80f689535b0dec3