### PR TITLE
Update MIPS arch detection

### DIFF
--- a/src/files/usr/bin/proxymaster.sh
+++ b/src/files/usr/bin/proxymaster.sh
@@ -26,7 +26,11 @@ case "$ARCH_RAW" in
         ARCH="mipsle"
         ;;
     mips)
-        ARCH="mips"
+        if grep -qi "little endian" /proc/cpuinfo; then
+            ARCH="mipsle"
+        else
+            ARCH="mips"
+        fi
         ;;
     *)
         logger -t pmaster "Unsupported architecture: $ARCH_RAW"


### PR DESCRIPTION
## Summary
- adapt proxymaster architecture detection for little-endian MIPS devices

## Testing
- `node config-generator/index.test.js`

------
https://chatgpt.com/codex/tasks/task_b_685f15840b64832fbe65aa51d71f7061