### PR TITLE
Improve uploader filler script with state tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Another helper script `online_users.sh` reports how many devices are currently c
 
 ## Monitoring Panel and Dummy Traffic
 A simple monitoring panel shows VNStat bandwidth statistics, including a TX/RX ratio updated every minute by `update_panel.sh`. To help keep the ratio reasonable, the helper script `uploader_filler.sh` may upload random data to [transfer.sh](https://transfer.sh) when received traffic greatly exceeds transmitted traffic.
+`uploader_filler.sh` now stores the previous receive and transmit counters in `/var/tmp/uploader_filler_state`. If this file is missing, the current counters are recorded and the script exits without uploading. On subsequent runs it compares the difference in RX and TX bytes since the last invocation and only performs an upload when 80% of the received bytes is still greater than the transmitted bytes. The current counters are always written back to the state file so the next run can determine the delta.

--- a/server/Iran_server/uploader_filler.sh
+++ b/server/Iran_server/uploader_filler.sh
@@ -1,16 +1,36 @@
 #!/bin/bash
 
 # This helper script attempts to keep upstream and downstream bandwidth usage
-# closer together by sending dummy data when inbound traffic far exceeds
-# outbound traffic.  Random bytes are uploaded to transfer.sh, which is a
-# free temporary file sharing service.  Only when the received amount is more
-# than 1 MB greater than the transmitted amount will the upload occur.
+# closer together by sending dummy data when inbound traffic greatly exceeds
+# outbound traffic.  Random bytes are uploaded to transfer.sh, which is a free
+# temporary file sharing service.
+
+STATE_FILE=/var/tmp/uploader_filler_state
 
 RX=$(cat /sys/class/net/eth0/statistics/rx_bytes)
 TX=$(cat /sys/class/net/eth0/statistics/tx_bytes)
-DIFF=$(( RX - TX ))
 
-if [ "$DIFF" -gt 1048576 ]; then
-  head -c "$DIFF" /dev/urandom | \
-    curl -m 20 --silent --upload-file - https://transfer.sh/$$.bin >/dev/null
+if [ ! -f "$STATE_FILE" ]; then
+  echo "$RX $TX" > "$STATE_FILE"
+  exit 0
 fi
+
+read PREV_RX PREV_TX < "$STATE_FILE"
+
+RX_DIFF=$(( RX - PREV_RX ))
+TX_DIFF=$(( TX - PREV_TX ))
+
+# Guard against counter reset
+if [ "$RX_DIFF" -lt 0 ]; then RX_DIFF=0; fi
+if [ "$TX_DIFF" -lt 0 ]; then TX_DIFF=0; fi
+
+# Only upload when 80% of received traffic is still greater than transmitted
+if [ $(( RX_DIFF * 8 / 10 )) -gt "$TX_DIFF" ]; then
+  DIFF=$(( RX_DIFF - TX_DIFF ))
+  if [ "$DIFF" -gt 0 ]; then
+    head -c "$DIFF" /dev/urandom | \
+      curl -m 20 --silent --upload-file - https://transfer.sh/$$.bin >/dev/null
+  fi
+fi
+
+echo "$RX $TX" > "$STATE_FILE"


### PR DESCRIPTION
## Summary
- update uploader_filler.sh to track previous rx/tx counters
- store counters in `/var/tmp/uploader_filler_state`
- skip upload on first run and when tx is within 80% of rx
- document uploader filler logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f17fdc0e0832fbb4ad38574c8ea31