### PR TITLE
Fix CSS order for bootstrap overrides

### DIFF
--- a/src/files/www/dashboard/dashboard.html
+++ b/src/files/www/dashboard/dashboard.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <title>Dashboard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="materialize/materialize.min.css">
     <link rel="stylesheet" href="styles/bootstrap.min.css">
     <link rel="stylesheet" href="styles/style.css">
-    <link rel="stylesheet" href="materialize/materialize.min.css">
     <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="materialize/materialize.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>


### PR DESCRIPTION
## Summary
- make sure Materialize is loaded before Bootstrap in dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685fb37f2200832f8700c0f4d9a9f131