### PR TITLE
Switch dashboard to Materialize

### DIFF
--- a/src/files/www/dashboard/check.html
+++ b/src/files/www/dashboard/check.html
@@ -4,22 +4,22 @@
     <meta charset="UTF-8">
     <title>Link Check</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
-    <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
-    <script type="text/javascript" src="scripts/common/loading.js" defer></script>
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
+        <link rel="stylesheet" href="styles/style.css">
+        <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/check.js" defer></script>
 </head>
 <body>
 <div class="container mt-3">
-    <a id="back-btn-href" class="btn btn-outline-secondary mb-3" href="dashboard.html">Back to Dashboard</a>
+    <a id="back-btn-href" class="btn-flat grey-text text-darken-2 mb-3" href="dashboard.html">Back to Dashboard</a>
 
     <div class="mb-3">
         <label class="form-label">Starlink Host/IP</label>
         <div class="input-group">
             <input type="text" class="form-control" id="starlink-host" placeholder="8.8.8.8">
-            <button class="btn btn-primary" id="starlink-check">Check</button>
+            <button class="btn blue" id="starlink-check">Check</button>
         </div>
         <div id="starlink-result" class="mt-1"></div>
     </div>
@@ -28,18 +28,18 @@
         <label class="form-label">Iran Host/IP</label>
         <div class="input-group">
             <input type="text" class="form-control" id="iran-host" placeholder="5.52.0.1">
-            <button class="btn btn-primary" id="iran-check">Check</button>
+            <button class="btn blue" id="iran-check">Check</button>
         </div>
         <div id="iran-result" class="mt-1"></div>
     </div>
 
     <div class="mb-3">
-        <button class="btn btn-secondary" id="vpn-check">Check VPN</button>
+        <button class="btn grey" id="vpn-check">Check VPN</button>
         <span id="vpn-result" class="ms-2"></span>
     </div>
 
     <div class="mb-3">
-        <button class="btn btn-secondary" id="city-check">Check CityLink</button>
+        <button class="btn grey" id="city-check">Check CityLink</button>
         <span id="city-result" class="ms-2"></span>
     </div>
 </div>

--- a/src/files/www/dashboard/citylink.html
+++ b/src/files/www/dashboard/citylink.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Step 5</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
     <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/citylink.js" defer></script>
@@ -18,7 +18,7 @@
         <!-- Button container with border -->
         <div class="row button-container justify-content-between mt-3 align-items-center">
             <div class="col-auto">
-                <a id="back-btn-href" href="guest.html" class="btn btn-light">
+                <a id="back-btn-href" href="guest.html" class="btn grey lighten-3 black-text">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-left" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M12.5 15a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5M10 8a.5.5 0 0 1-.5.5H3.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L3.707 7.5H9.5a.5.5 0 0 1 .5.5"/>
                     </svg>
@@ -29,7 +29,7 @@
                 <h6 class="mb-0">Step 5:<br>CityLink - Setup Access to Starlink via Iran Internet</h6>
             </div>
             <div class="col-auto">
-                <a href="dashboard.html" class="btn btn-light">Dashboard  
+                <a href="dashboard.html" class="btn grey lighten-3 black-text">Dashboard  
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-right" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M6 8a.5.5 0 0 0 .5.5h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L12.293 7.5H6.5A.5.5 0 0 0 6 8m-2.5 7a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5"/>
                     </svg>
@@ -41,11 +41,10 @@
         <div class="row justify-content-center mt-3">
             
             <!-- Note -->
-            <div class="alert alert-info alert-dismissible fade show" role="alert" >
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
+            <div class="card-panel blue lighten-4" role="alert" >
                 <div class="english-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm fa-btn">فارسی</button>
+                        <button type="button" class="btn btn-flat btn-sm fa-btn">فارسی</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">Note:</h6>
                     You can now configure CityLink to access your autonomous internet source (e.g., Starlink) remotely through the Iranian internet network.
@@ -58,7 +57,7 @@
                 </div>
                 <div dir="rtl" class="farsi-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm en-btn">English</button>
+                        <button type="button" class="btn btn-flat btn-sm en-btn">English</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">توضیحات:</h6>
                     اکنون می‌توانید با پیکربندی سیتی‌لینک (CityLink) از راه دور از طریق شبکه داخلی اینترنت کشور به استارلینک دسترسی پیدا کنید.
@@ -73,10 +72,10 @@
             </div>
             
             <!-- How to  -->
-            <div class="alert alert-light" role="alert">
+            <div class="card-panel grey lighten-5" role="alert">
                 <div class="english-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm fa-btn">فارسی</button>
+                        <button type="button" class="btn btn-flat btn-sm fa-btn">فارسی</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">Instruction:</h6>
                     <ul>
@@ -90,7 +89,7 @@
                 </div>
                 <div dir="rtl" class="farsi-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm en-btn">English</button>
+                        <button type="button" class="btn btn-flat btn-sm en-btn">English</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">راهنما</h6>
                     <ul>
@@ -111,7 +110,7 @@
         <div class="container row">
             <div id="alertContainer" class="col"></div>
         </div>
-        <div id="connection-status" class="row alert alert-danger justify-content-center align-items-center">
+        <div id="connection-status" class="row card-panel red lighten-4 justify-content-center align-items-center">
             <div class="col">
                 <div class="row">
                     <div class="col text-start">
@@ -125,7 +124,7 @@
                 </div>
             </div>
             <div class="col text-end">
-                <button class="btn btn-outline-light d-none" type="button" id="disconnect-btn">
+                <button class="btn btn-flat d-none" type="button" id="disconnect-btn">
                     <span>Disconnect</span>
                 </button>
             </div>
@@ -133,7 +132,7 @@
         <div class="input-group my-3" id="connection-section">
             <span class="input-group-text" id="connection-part">Connection String</span>
             <input id="connection-string" type="text" class="form-control" placeholder="InR:string:string:...@host" aria-label="Username" aria-describedby="connection-part">
-            <button class="btn btn-primary" type="button" id="connect-btn" style="width: 85px">
+            <button class="btn blue" type="button" id="connect-btn" style="width: 85px">
                 <span>Connect</span>
                 <div class="spinner-grow spinner-grow-sm text-light" role="status" style="display: none">
                     <span class="visually-hidden">Loading...</span>
@@ -149,7 +148,7 @@
                     <div class="card-body">
                         <h3 class="card-title">Outline Relay</h4>
                         <p class="card-text text-body fw-lighter" >Convert Global Outline config to use in Iran</p> 
-                        <a href="outline.html" class="btn btn-outline-primary">setup</a>
+                        <a href="outline.html" class="btn btn-flat blue-text">setup</a>
                     </div>
                 </div>
                 
@@ -160,7 +159,7 @@
                     <div class="card-body">
                         <h3 class="card-title">HTTPS Proxy</h4>
                         <p class="card-text text-body fw-lighter" >Proxy configuration</p> 
-                        <a href="proxy.html" class="btn btn-outline-primary">setup</a>
+                        <a href="proxy.html" class="btn btn-flat blue-text">setup</a>
                     </div>
                 </div>
                 
@@ -181,9 +180,6 @@
         </div>
     </div> 
  
-    <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-        <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" style="width: 100%">
-            <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
         </div>
     </div>
 </body>

--- a/src/files/www/dashboard/dashboard.html
+++ b/src/files/www/dashboard/dashboard.html
@@ -6,10 +6,8 @@
     <title>Dashboard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="materialize/materialize.min.css">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
-    <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
-    <script type="text/javascript" src="materialize/materialize.min.js" defer></script>
+        <link rel="stylesheet" href="styles/style.css">
+        <script type="text/javascript" src="materialize/materialize.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/dashboard.js" defer></script>
@@ -20,7 +18,7 @@
     <div class="container row align-items-center justify-content-center text-center min-vh-100 px-1">
         <div class="col-auto mx-3">
             <div class="row mt-3">
-                <button id="starlink-btn" type="button" class="btn btn-success text-start">
+                <button id="starlink-btn" type="button" class="btn green text-start">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-wifi" viewBox="0 0 16 16">
                         <path
@@ -33,7 +31,7 @@
                 </button>
             </div>
             <div class="row mt-3">
-                <button id="iran-btn" type="button" class="btn btn-success text-start">
+                <button id="iran-btn" type="button" class="btn green text-start">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-ethernet" viewBox="0 0 16 16">
                         <path
@@ -46,7 +44,7 @@
                 </button>
             </div>
             <div class="row mt-3">
-                <button id="settings-btn" type="button" class="btn btn-info text-start">
+                <button id="settings-btn" type="button" class="btn blue text-start">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-gear-fill" viewBox="0 0 16 16">
                         <path
@@ -57,7 +55,7 @@
                 </button>
             </div>
             <div class="row mt-3">
-                <button id="vpn-btn" type="button" class="btn btn-success text-start">
+                <button id="vpn-btn" type="button" class="btn green text-start">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-gear-fill" viewBox="0 0 16 16">
                         <path
@@ -68,7 +66,7 @@
                 </button>
             </div>
             <div class="row mt-3">
-                <button id="guest-btn" type="button" class="btn btn-success text-start">
+                <button id="guest-btn" type="button" class="btn green text-start">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-people-fill" viewBox="0 0 16 16">
                         <path
@@ -79,7 +77,7 @@
                 </button>
             </div>
             <div class="row mt-3">
-                <button id="reach-btn" type="button" class="btn btn-success text-start">
+                <button id="reach-btn" type="button" class="btn green text-start">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-hdd-network-fill" viewBox="0 0 16 16">
                         <path
@@ -91,7 +89,7 @@
                 </button>
             </div>
             <div class="row mt-3">
-                <button id="firmware-btn" type="button" class="btn btn-secondary text-start">
+                <button id="firmware-btn" type="button" class="btn grey text-start">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-arrow-repeat" viewBox="0 0 16 16">
                         <path
@@ -104,7 +102,7 @@
                 </button>
             </div>
             <div class="row mt-3">
-                <button id="logs-btn" type="button" class="btn btn-secondary text-start">
+                <button id="logs-btn" type="button" class="btn grey text-start">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M2.5 12.5a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1h-10a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1h-10a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1h-10a.5.5 0 0 1-.5-.5z"/>
                     </svg>
@@ -113,7 +111,7 @@
                 </button>
             </div>
             <div class="row mt-3">
-                <button id="check-btn" type="button" class="btn btn-secondary text-start">
+                <button id="check-btn" type="button" class="btn grey text-start">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-activity" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M0 8a.5.5 0 0 1 .5-.5h2.707l2-4A.5.5 0 0 1 5.5 3h.001a.5.5 0 0 1 .462.308L8.147 8.5H11.5a.5.5 0 0 1 .45.725l-2 4a.5.5 0 0 1-.9-.005L7.186 9.5H3.854l-1.5 3A.5.5 0 0 1 1.9 13H.5a.5.5 0 0 1-.5-.5V8z"/>
                     </svg>
@@ -166,9 +164,9 @@
 
                 <!-- Warning -->
                 <div id="warning-part" class="row container justify-content-start mt-3">
-                    <div class="alert alert-warning text-start d-none" id="english-alert" role="alert">
+                    <div class="card-panel yellow lighten-4 text-start d-none" id="english-alert" role="alert">
                         <div class="position-absolute top-0 end-0" style="margin-top: 3px; margin-right: 3px;">
-                            <button id="fa-btn" class="btn btn-outline-light btn-sm" for="fa-btn">فارسی</button>
+                            <button id="fa-btn" class="btn btn-flat btn-sm" for="fa-btn">فارسی</button>
                         </div>
 
                         <h5 class="alert-heading mb-1 text-center">Warning!</h5>
@@ -182,9 +180,9 @@
                         </ol>
                     </div>
 
-                    <div dir="rtl" class="alert alert-warning text-end" id="farsi-alert" role="alert">
+                    <div dir="rtl" class="card-panel yellow lighten-4 text-end" id="farsi-alert" role="alert">
                         <div class="position-absolute top-0 end-0" style="margin-top: 3px; margin-right: 3px;">
-                            <button id="en-btn" type="button" class="btn btn-outline-light btn-sm">English</button>
+                            <button id="en-btn" type="button" class="btn btn-flat btn-sm">English</button>
                         </div>
 
                         <h5 class="alert-heading mb-1 text-center">هشدار</h5>
@@ -218,10 +216,6 @@
         </div>
     </div>
 
-    <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-        <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000"
-            style="width: 100%">
-            <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
         </div>
     </div>
 </body>

--- a/src/files/www/dashboard/ethernet.html
+++ b/src/files/www/dashboard/ethernet.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <title>Step 2</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
     <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/ethernet.js" defer></script>
@@ -19,7 +19,7 @@
         <!-- Button container with border -->
         <div class="row button-container justify-content-between mt-3 align-items-center">
             <div class="col-auto">
-                <a id="back-btn-href" href="wifi.html" class="btn btn-light">
+                <a id="back-btn-href" href="wifi.html" class="btn grey lighten-3 black-text">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-arrow-bar-left" viewBox="0 0 16 16">
                         <path fill-rule="evenodd"
@@ -32,8 +32,8 @@
                 <h6 class="mb-0">Step 2: Connect NeighborLink to Iran Internet</h6>
             </div>
             <div class="col-auto">
-                <a href="dashboard.html" class="btn btn-link">Dashboard</a>
-                <a href="vpn.html" class="btn btn-light">Next
+                <a href="dashboard.html" class="btn-flat">Dashboard</a>
+                <a href="vpn.html" class="btn grey lighten-3 black-text">Next
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-arrow-bar-right" viewBox="0 0 16 16">
                         <path fill-rule="evenodd"
@@ -47,8 +47,7 @@
         <div class="row justify-content-center mt-3">
 
             <!-- Note -->
-            <div class="alert alert-info alert-dismissible fade show" role="alert">
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            <div class="card-panel blue lighten-4" role="alert">
                 <div>
                     In this step, we connect NeighborLink to the Iranian internet. The goal is to ensure that you can access both domestic services and later, in the CityLink section, connect remotely to Starlink via the domestic internet.
                 </div>
@@ -59,7 +58,7 @@
             </div>
 
             <!-- How to  -->
-            <div class="row alert alert-light" role="alert">
+            <div class="row card-panel grey lighten-5" role="alert">
                 <div class="col-auto">
                     <strong>Instruction:</strong>
                     <ul>
@@ -80,7 +79,7 @@
 
         <div class="row container justify-content-start">
             <div class="col-6">
-                <button class="btn btn-primary px-4 py-3" id="check-eth-btn">
+                <button class="btn blue px-4 py-3" id="check-eth-btn">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-ethernet" viewBox="0 0 16 16">
                         <path
@@ -91,7 +90,7 @@
                     Check Connection
                 </button>
             </div>
-            <div id="connection-status" class="col-6 alert alert-danger justify-content-center align-items-center">
+            <div id="connection-status" class="col-6 card-panel red lighten-4 justify-content-center align-items-center">
                 <div class="row">
                     <div class="col text-start">
                         <strong>Status: Disconnected</strong>
@@ -115,10 +114,6 @@
             </div>
         </div>
 
-        <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-            <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000"
-                style="width: 100%">
-                <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
             </div>
         </div>
 

--- a/src/files/www/dashboard/firmware.html
+++ b/src/files/www/dashboard/firmware.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Firmware</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
     <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/firmware.js" defer></script>
@@ -17,7 +17,7 @@
         <!-- Button container with border -->
         <div class="row button-container justify-content-between mt-3 align-items-center">
             <div class="col-auto">
-                <a id="back-btn-href" href="dashboard.html" class="btn btn-light">
+                <a id="back-btn-href" href="dashboard.html" class="btn grey lighten-3 black-text">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-left" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M12.5 15a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5M10 8a.5.5 0 0 1-.5.5H3.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L3.707 7.5H9.5a.5.5 0 0 1 .5.5"/>
                     </svg>
@@ -33,15 +33,14 @@
         <div class="row justify-content-center mt-3">
             
             <!-- Note -->
-            <div class="alert alert-info alert-dismissible fade show" role="alert" >
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
+            <div class="card-panel blue lighten-4" role="alert" >
                 <strong>Note:</strong>
                 <br>After Upgrade You will be disconnected from Open-Router
                 <br>Do not Unplug the Router During the update
             </div>
             
             <!-- How to  -->
-            <div class="alert alert-light" role="alert">
+            <div class="card-panel grey lighten-5" role="alert">
                 <strong>Steps:</strong>
                 <ul>
                     <li>Check for update</li>
@@ -56,7 +55,7 @@
                     <input type="text" id="update-url" class="form-control" style="max-width: 500px;" value="https://api.github.com/repos/nasnet-community/neighbor-link/releases/latest">
                 </div>
                 <div class="row d-flex justify-content-center mb-3 mt-3">
-                    <button type="button" class="col-auto btn btn-primary" id="check-update" >
+                    <button type="button" class="col-auto btn blue" id="check-update" >
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-repeat" viewBox="0 0 16 16">
                             <path d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41m-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9"/>
                             <path fill-rule="evenodd" d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5 5 0 0 0 8 3M3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9z"/>
@@ -64,7 +63,7 @@
                         Check for Update
                     </button>
                     
-                    <button type="button" class="col-auto btn btn-success mx-2 d-none" id="do-update">
+                    <button type="button" class="col-auto btn green mx-2 d-none" id="do-update">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-in-up" viewBox="0 0 16 16">
                             <path fill-rule="evenodd" d="M3.5 10a.5.5 0 0 1-.5-.5v-8a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 .5.5v8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 0 0 1h2A1.5 1.5 0 0 0 14 9.5v-8A1.5 1.5 0 0 0 12.5 0h-9A1.5 1.5 0 0 0 2 1.5v8A1.5 1.5 0 0 0 3.5 11h2a.5.5 0 0 0 0-1z"/>
                             <path fill-rule="evenodd" d="M7.646 4.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707V14.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708z"/>
@@ -75,7 +74,7 @@
                 <div class="row d-flex justify-content-center text-center my-3">
                     <label class="p-2 text-info" id="update-notif">Please press the "Check for Update" button</label>
                 </div>
-                <div class="alert alert-warning mb-5" role="alert" id="update-waiting-alert">
+                <div class="card-panel yellow lighten-4 mb-5" role="alert" id="update-waiting-alert">
                     Update will take about 10 minutes, Please do not discounnect the power cable, please reconnect to the router after 10 minites and reload this page.
                 </div>
             </div>
@@ -92,9 +91,6 @@
             </div>
         </div> 
      
-        <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-            <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" style="width: 100%">
-                <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
             </div>
         </div>
 

--- a/src/files/www/dashboard/guest.html
+++ b/src/files/www/dashboard/guest.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Step 4</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
     <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/guest.js" defer></script>
@@ -17,7 +17,7 @@
         <!-- Button container with border -->
         <div class="row button-container justify-content-between mt-3 align-items-center">
             <div class="col-auto">
-                <a id="back-btn-href" href="vpn.html" class="btn btn-light">
+                <a id="back-btn-href" href="vpn.html" class="btn grey lighten-3 black-text">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-left" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M12.5 15a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5M10 8a.5.5 0 0 1-.5.5H3.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L3.707 7.5H9.5a.5.5 0 0 1 .5.5"/>
                     </svg>
@@ -28,8 +28,8 @@
                 <h6 class="mb-0">Step 4: Access for Neighbors</h6>
             </div>
             <div class="col-auto">
-                <a href="dashboard.html" class="btn btn-link">Dashboard</a>
-                <a href="citylink.html" class="btn btn-light">Next 
+                <a href="dashboard.html" class="btn-flat">Dashboard</a>
+                <a href="citylink.html" class="btn grey lighten-3 black-text">Next 
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-right" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M6 8a.5.5 0 0 0 .5.5h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L12.293 7.5H6.5A.5.5 0 0 0 6 8m-2.5 7a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5"/>
                 </svg>
@@ -41,8 +41,7 @@
         <div class="row justify-content-center mt-3">
             
             <!-- Note -->
-            <div class="alert alert-info alert-dismissible fade show mx-1" role="alert" >
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
+            <div class="card-panel blue lighten-4 mx-1" role="alert" >
                 <div>
                     In this step, we first configure the Guest Wi-Fi settings to allow neighbors to access Starlink. Then, we create individual accounts for each neighbor (user) with a personal username and password.
                 </div>
@@ -53,7 +52,7 @@
             </div>
             
             <!-- How to  -->
-            <div class="row alert alert-light mx-1" role="alert">
+            <div class="row card-panel grey lighten-5 mx-1" role="alert">
                 <strong>Instruction:</strong>
                 <div class="col-auto">
                     <ul>
@@ -115,7 +114,7 @@
                     <div class="form-text">Password must be in english and has 8 characters .</div>
                 </div>
                 <div class="d-flex col-auto text-center justify-content-center pb-4 pt-1">
-                    <button type="button" class="btn btn-success mt-4" id="guest-update">Update</button>
+                    <button type="button" class="btn green mt-4" id="guest-update">Update</button>
                 </div>
             </div>
             
@@ -123,7 +122,7 @@
             <hr>
             <div class="d-flex row container justify-content-center">
                 <div class="col-auto text-center" >
-                    <button class="btn btn-outline-light px-4 py-3" id="user-management">
+                    <button class="btn btn-flat px-4 py-3" id="user-management">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-people-fill" viewBox="0 0 16 16">
                             <path d="M7 14s-1 0-1-1 1-4 5-4 5 3 5 4-1 1-1 1zm4-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6m-5.784 6A2.24 2.24 0 0 1 5 13c0-1.355.68-2.75 1.936-3.72A6.3 6.3 0 0 0 5 9c-4 0-5 3-5 4s1 1 1 1zM4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5"/>
                         </svg>
@@ -186,9 +185,6 @@
         </div>
     </div> 
  
-    <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-        <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" style="width: 100%">
-            <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
         </div>
     </div>
 </body>

--- a/src/files/www/dashboard/logs.html
+++ b/src/files/www/dashboard/logs.html
@@ -4,21 +4,21 @@
     <meta charset="UTF-8">
     <title>Connection Logs</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
-    <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
-    <script type="text/javascript" src="scripts/common/loading.js" defer></script>
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
+        <link rel="stylesheet" href="styles/style.css">
+        <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/logs.js" defer></script>
 </head>
 <body>
 <div class="container mt-3">
-    <a id="back-btn-href" class="btn btn-outline-secondary mb-3" href="dashboard.html">Back to Dashboard</a>
+    <a id="back-btn-href" class="btn-flat grey-text text-darken-2 mb-3" href="dashboard.html">Back to Dashboard</a>
     <div class="btn-group mb-3" role="group">
-        <button class="btn btn-secondary" data-type="starlink">Starlink</button>
-        <button class="btn btn-secondary" data-type="iran">Iran</button>
-        <button class="btn btn-secondary" data-type="vpn">VPN</button>
-        <button class="btn btn-secondary" data-type="citylink">CityLink</button>
+        <button class="btn grey" data-type="starlink">Starlink</button>
+        <button class="btn grey" data-type="iran">Iran</button>
+        <button class="btn grey" data-type="vpn">VPN</button>
+        <button class="btn grey" data-type="citylink">CityLink</button>
     </div>
     <h6 id="log-title" class="mb-2">Starlink Log</h6>
     <pre id="log-content" class="bg-body-secondary p-2" style="height:60vh; overflow:auto;"></pre>

--- a/src/files/www/dashboard/management.html
+++ b/src/files/www/dashboard/management.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <title>Dashboard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
-    <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
-    <script type="text/javascript" src="scripts/common/loading.js" defer></script>
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
+        <link rel="stylesheet" href="styles/style.css">
+        <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
 </head>
 <body>
@@ -17,10 +17,9 @@
     
                 <div role="alert" id="notif">
                     <label id="notif-message"><!-- do not delete --></label>
-                    <button type="button" class="btn-close" id="close-notif"></button>
                 </div>
     
-                <a class="btn btn-outline-secondary mb-3" href="guest.html?ref=dashboard">Back to Dashboard</a>
+                <a class="btn-flat grey-text text-darken-2 mb-3" href="guest.html?ref=dashboard">Back to Dashboard</a>
                 
                 <h1>User Management</h1>
                 <div class="card p-4">
@@ -41,8 +40,8 @@
                             <label for="maxDevices" class="form-label">Max Devices</label>
                             <input type="number" class="form-control" id="maxDevices" min="0">
                         </div>
-                        <input type="button" id="modify-user-btn" class="btn btn-success" value="Add User" onclick="addUser()">
-                        <button type="reset" class="btn btn-outline-dark" onclick="resetForm()">Cancel</button>
+                        <input type="button" id="modify-user-btn" class="btn green" value="Add User" onclick="addUser()">
+                        <button type="reset" class="btn-flat black-text" onclick="resetForm()">Cancel</button>
                     </form>
                 </div>
     
@@ -75,13 +74,12 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Confirmation</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <p>Are you sure that you want to delete <span class="badge bg-warning text-body" id="modal-username">this user</span>?</p>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn grey" data-bs-dismiss="modal">Cancel</button>
                     <button type="button" class="btn btn-danger" id="modal-delete-btn" onclick="deleteUser(this)" data-username="">Yes, Delete it.</button>
                 </div>
             </div>

--- a/src/files/www/dashboard/outline.html
+++ b/src/files/www/dashboard/outline.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Step 5</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
     <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/outline.js" defer></script>
@@ -17,7 +17,7 @@
         <!-- Button container with border -->
         <div class="row button-container justify-content-between mt-3 align-items-center">
             <div class="col-auto">
-                <a id="back-btn-href" href="citylink.html" class="btn btn-light">
+                <a id="back-btn-href" href="citylink.html" class="btn grey lighten-3 black-text">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-left" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M12.5 15a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5M10 8a.5.5 0 0 1-.5.5H3.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L3.707 7.5H9.5a.5.5 0 0 1 .5.5"/>
                     </svg>
@@ -34,11 +34,10 @@
         <div class="row justify-content-center mt-3">
             
             <!-- Note -->
-            <div class="alert alert-info alert-dismissible fade show" role="alert" >
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
+            <div class="card-panel blue lighten-4" role="alert" >
                 <div class="english-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm fa-btn">فارسی</button>
+                        <button type="button" class="btn btn-flat btn-sm fa-btn">فارسی</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">Note:</h6>
                     <p>
@@ -47,7 +46,7 @@
                 </div>
                 <div dir="rtl" class="farsi-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm en-btn">English</button>
+                        <button type="button" class="btn btn-flat btn-sm en-btn">English</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">توضیحات</h6>
                     <p>
@@ -57,10 +56,10 @@
             </div>
             
             <!-- How to  -->
-            <div class="alert alert-light" role="alert">
+            <div class="card-panel grey lighten-5" role="alert">
                 <div class="english-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm fa-btn">فارسی</button>
+                        <button type="button" class="btn btn-flat btn-sm fa-btn">فارسی</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">Instruction:</h6>
                     <ul>
@@ -72,7 +71,7 @@
                 </div>
                 <div dir="rtl" class="farsi-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm en-btn">English</button>
+                        <button type="button" class="btn btn-flat btn-sm en-btn">English</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">راهنما</h6>
                     <ul>
@@ -100,7 +99,7 @@
                 <div id="alertContainer" ></div>
             </div>
 
-            <div class="alert alert-primary mt-2" role="alert">
+            <div class="card-panel blue lighten-4 mt-2" role="alert">
                 <h4 class="alert-heading">Converted Config</h4>
                 <hr>
                 <p  id="out-access-key" class="mb-0 text-wrap text-break fw-lighter">
@@ -111,7 +110,7 @@
             <h6 class="text text-info" id="basic-addon1">Past original accesskey here</h6>
             <div class="input-group mb-4">
                 <input id="access-key" type="text" class="form-control" placeholder="ss://access-key" aria-label="Username" aria-describedby="basic-addon1">
-                <button class="btn btn-primary" type="button" id="outline-convert">Convert</button>
+                <button class="btn blue" type="button" id="outline-convert">Convert</button>
             </div>
             <span class="my-4">&nbsp</span>
             
@@ -129,9 +128,6 @@
         </div>
     </div> 
  
-    <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-        <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" style="width: 100%">
-            <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
         </div>
     </div>
 </body>

--- a/src/files/www/dashboard/proxy.html
+++ b/src/files/www/dashboard/proxy.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Step 5</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
     <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/proxy.js" defer></script>
@@ -17,7 +17,7 @@
         <!-- Button container with border -->
         <div class="row button-container justify-content-between mt-3 align-items-center">
             <div class="col-auto">
-                <a id="back-btn-href" href="citylink.html" class="btn btn-light">
+                <a id="back-btn-href" href="citylink.html" class="btn grey lighten-3 black-text">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-left" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M12.5 15a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5M10 8a.5.5 0 0 1-.5.5H3.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L3.707 7.5H9.5a.5.5 0 0 1 .5.5"/>
                     </svg>
@@ -34,11 +34,10 @@
         <div class="row justify-content-center mt-3">
             
             <!-- Note -->
-            <div class="alert alert-info alert-dismissible fade show" role="alert" >
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
+            <div class="card-panel blue lighten-4" role="alert" >
                 <div class="english-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm fa-btn">فارسی</button>
+                        <button type="button" class="btn btn-flat btn-sm fa-btn">فارسی</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">Note:</h6>
                     <p>
@@ -48,7 +47,7 @@
                 </div>
                 <div dir="rtl" class="farsi-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm en-btn">English</button>
+                        <button type="button" class="btn btn-flat btn-sm en-btn">English</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">توضیحات</h6>
                     <p>
@@ -59,10 +58,10 @@
             </div>
             
             <!-- How to  -->
-            <div class="alert alert-light" role="alert">
+            <div class="card-panel grey lighten-5" role="alert">
                 <div class="english-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm fa-btn">فارسی</button>
+                        <button type="button" class="btn btn-flat btn-sm fa-btn">فارسی</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">Instruction:</h6>
                     <ul>
@@ -73,7 +72,7 @@
                 </div>
                 <div dir="rtl" class="farsi-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
-                        <button type="button" class="btn btn-outline-light btn-sm en-btn">English</button>
+                        <button type="button" class="btn btn-flat btn-sm en-btn">English</button>
                     </div>
                     <h6 class="alert-heading mb-1 text-center">راهنما</h6>
                     <ul>
@@ -133,9 +132,6 @@
         </div>
     </div> 
  
-    <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-        <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" style="width: 100%">
-            <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
         </div>
     </div>
 </body>

--- a/src/files/www/dashboard/scripts/common/heartBeat.js
+++ b/src/files/www/dashboard/scripts/common/heartBeat.js
@@ -1,5 +1,3 @@
-const toastLiveExample = document.getElementById('liveToast')
-const toastBootstrap = bootstrap.Toast.getOrCreateInstance(toastLiveExample)
 var toastShowCount = 0;
 var isSet=false
 const buildVersionLabel = document.getElementById('build-version')
@@ -7,7 +5,7 @@ function heartBeat() {
     const Device_ID=["uci", "get", {"config":"routro"}];
     ubus_call(Device_ID,function(chunk){
         if(chunk[0] !== 0) {
-            toastBootstrap.show()
+            M.toast({html: "You're not connected to router!", classes: 'red'});
             toastShowCount++
         } 
         else if(chunk[1]?.values?.firmware?.version){

--- a/src/files/www/dashboard/scripts/common/loading.js
+++ b/src/files/www/dashboard/scripts/common/loading.js
@@ -44,66 +44,8 @@ document.addEventListener("DOMContentLoaded", function() {
 })
 
 function addCustomAlert(title, message, visibilityTime) {
-    const alertContainer = document.getElementById('alertContainer');
-
-    const alertDiv = document.createElement('div');
-    alertDiv.className = 'alert alert-warning alert-dismissible fade show';
-    alertDiv.role = 'alert';
-
-    // Title on its own line
-    const strongText = document.createElement('strong');
-    strongText.innerText = title;
-    strongText.style.display = 'block'; // Make title a block element to appear on a new line
-
-    // Message on its own line
-    const alertMessage = document.createElement('span');
-    alertMessage.innerText = message;
-    alertMessage.style.display = 'block'; // Make message a block element to appear on a new line
-    alertMessage.style.marginTop = '5px'; // Optional: Adds some spacing between title and message
-
-    // Container for close button and countdown text
-    const buttonContainer = document.createElement('div');
-    buttonContainer.style.display = 'flex';
-    buttonContainer.style.flexDirection = 'column';
-    buttonContainer.style.alignItems = 'flex-end'; // Aligns items to the right
-
-    const closeButton = document.createElement('button');
-    closeButton.type = 'button';
-    closeButton.className = 'btn-close';
-    closeButton.setAttribute('data-bs-dismiss', 'alert');
-    closeButton.setAttribute('aria-label', 'Close');
-
-    const countdownSpan = document.createElement('span');
-    countdownSpan.style.fontSize = '0.8em'; // Smaller font size for the countdown
-    countdownSpan.style.marginTop = '5px'; // Adds a little space between button and countdown
-    let countdown = Math.floor((visibilityTime || 20000) / 1000); // Convert visibility time to seconds
-    countdownSpan.innerText = `(${countdown})`;
-
-    buttonContainer.appendChild(closeButton);
-    buttonContainer.appendChild(countdownSpan);
-
-    alertDiv.appendChild(strongText); // Append title
-    alertDiv.appendChild(alertMessage); // Append message
-    alertDiv.appendChild(buttonContainer); // Add the button container to the alert
-
-    alertContainer.appendChild(alertDiv);
-
-    // Update the countdown every second
-    const interval = setInterval(() => {
-        countdown--;
-        countdownSpan.innerText = `( ${countdown} )`;
-
-        if (countdown <= 0) {
-            clearInterval(interval); // Stop the interval when countdown is 0
-        }
-    }, 1000);
-
-    // Remove the alert after the specified visibility time
-    setTimeout(() => {
-        alertDiv.classList.remove('show'); // Hides the alert
-        alertDiv.classList.add('fade'); // Optional: adds fade-out effect
-        setTimeout(() => alertDiv.remove(), 500); // Removes it after fade out
-    }, visibilityTime || 20000);
+    const time = visibilityTime || 2000;
+    M.toast({html: `<strong>${title}</strong> ${message}`, classes: 'yellow darken-2', displayLength: time});
 }
 
 

--- a/src/files/www/dashboard/scripts/page-specific/citylink.js
+++ b/src/files/www/dashboard/scripts/page-specific/citylink.js
@@ -62,24 +62,24 @@ function changeStatus(status, underText) {
     if(status === "connected"){
         textBox.textContent = "Status: Connected"
         ssidBox.textContent = underText
-        connectionStatus.classList.remove("alert-danger","alert-warning")
-        connectionStatus.classList.add("alert-success")
+        connectionStatus.classList.remove("red","lighten-4","yellow","lighten-4")
+        connectionStatus.classList.add("green","lighten-4")
         disconnectButton.classList.remove("d-none")
         document.getElementById("config-cards").classList.remove("d-none")
         document.getElementById("connection-section").classList.add("d-none")
     } else if(status === "connecting"){
         textBox.textContent = "Status: Connecting..."
         ssidBox.textContent = underText || ""
-        connectionStatus.classList.remove("alert-danger","alert-success")
-        connectionStatus.classList.add("alert-warning")
+        connectionStatus.classList.remove("red","lighten-4","green","lighten-4")
+        connectionStatus.classList.add("yellow","lighten-4")
         disconnectButton.classList.add("d-none")
         document.getElementById("config-cards").classList.add("d-none")
         document.getElementById("connection-section").classList.add("d-none")
     } else {
         textBox.textContent = "Status: Disconnected"
         ssidBox.textContent = ""
-        connectionStatus.classList.remove("alert-success","alert-warning")
-        connectionStatus.classList.add("alert-danger")
+        connectionStatus.classList.remove("green","lighten-4","yellow","lighten-4")
+        connectionStatus.classList.add("red","lighten-4")
         disconnectButton.classList.add("d-none")
         document.getElementById("config-cards").classList.add("d-none")
         document.getElementById("connection-section").classList.remove("d-none")

--- a/src/files/www/dashboard/scripts/page-specific/ethernet.js
+++ b/src/files/www/dashboard/scripts/page-specific/ethernet.js
@@ -13,14 +13,14 @@ function changeStatus(theStatus,SSID) {
     if(theStatus){
         textBox.textContent = "Status: Connected"
         ssidBox.textContent = SSID
-        connectionStatus.classList.remove("alert-danger");
-        connectionStatus.classList.add("alert-success");
+        connectionStatus.classList.remove("red","lighten-4");
+        connectionStatus.classList.add("green","lighten-4");
     }
     else{
         textBox.textContent = "Status: Disconnected"
         ssidBox.textContent = ""
-        connectionStatus.classList.remove("alert-success");
-        connectionStatus.classList.add("alert-danger");
+        connectionStatus.classList.remove("green","lighten-4");
+        connectionStatus.classList.add("red","lighten-4");
     }
     
 }

--- a/src/files/www/dashboard/scripts/page-specific/guest.js
+++ b/src/files/www/dashboard/scripts/page-specific/guest.js
@@ -149,28 +149,7 @@ async function wifiInfo(){
 }
 
 function addCustomAlert(title, message) {
-    const alertContainer = document.getElementById('alertContainer');
-
-    const alertDiv = document.createElement('div');
-    alertDiv.className = 'alert alert-warning alert-dismissible fade show';
-    alertDiv.role = 'alert';
-
-    const strongText = document.createElement('strong');
-    strongText.innerText = title;
-
-    const alertMessage = document.createTextNode(' ' + message);
-
-    const closeButton = document.createElement('button');
-    closeButton.type = 'button';
-    closeButton.className = 'btn-close';
-    closeButton.setAttribute('data-bs-dismiss', 'alert');
-    closeButton.setAttribute('aria-label', 'Close');
-
-    alertDiv.appendChild(strongText);
-    alertDiv.appendChild(alertMessage);
-    alertDiv.appendChild(closeButton);
-
-    alertContainer.appendChild(alertDiv);
+    M.toast({html: '<strong>' + title + '</strong> ' + message, classes: 'yellow darken-2'});
 }
 
 

--- a/src/files/www/dashboard/scripts/page-specific/management.js
+++ b/src/files/www/dashboard/scripts/page-specific/management.js
@@ -171,14 +171,14 @@ function deleteUser(btn) {
         renderUserList();
     }
     SaveIN();
-    myModal.hide();
+    myModal.close();
 }
 
-const myModal = new bootstrap.Modal(document.getElementById('confirmModal'));
+const myModal = M.Modal.init(document.getElementById('confirmModal'));
 function deleteUserModal(username) {
     document.getElementById('modal-username').innerText = username;
     document.getElementById('modal-delete-btn').setAttribute('data-username', username);
-    myModal.show();
+    myModal.open();
 }
 
 // Function to add a user

--- a/src/files/www/dashboard/scripts/page-specific/wifi.js
+++ b/src/files/www/dashboard/scripts/page-specific/wifi.js
@@ -156,28 +156,7 @@ ConnectButton.onclick=function(){
 
 
 function addCustomAlert(title, message) {
-    const alertContainer = document.getElementById('alertContainer');
-
-    const alertDiv = document.createElement('div');
-    alertDiv.className = 'alert alert-warning alert-dismissible fade show';
-    alertDiv.role = 'alert';
-
-    const strongText = document.createElement('strong');
-    strongText.innerText = title;
-
-    const alertMessage = document.createTextNode(' ' + message);
-
-    const closeButton = document.createElement('button');
-    closeButton.type = 'button';
-    closeButton.className = 'btn-close';
-    closeButton.setAttribute('data-bs-dismiss', 'alert');
-    closeButton.setAttribute('aria-label', 'Close');
-
-    alertDiv.appendChild(strongText);
-    alertDiv.appendChild(alertMessage);
-    alertDiv.appendChild(closeButton);
-
-    alertContainer.appendChild(alertDiv);
+    M.toast({html: '<strong>' + title + '</strong> ' + message, classes: 'yellow darken-2'});
 }
 
 const connectionStatus =  document.getElementById("connection-status")
@@ -187,14 +166,14 @@ function changeStatus(theStatus,SSID) {
     if(theStatus){
         textBox.textContent = "Status: Connected"
         ssidBox.textContent = SSID
-        connectionStatus.classList.remove("alert-danger");
-        connectionStatus.classList.add("alert-success");
+        connectionStatus.classList.remove("red","lighten-4");
+        connectionStatus.classList.add("green","lighten-4");
     }
     else{
         textBox.textContent = "Status: Disconnected"
         ssidBox.textContent = ""
-        connectionStatus.classList.remove("alert-success");
-        connectionStatus.classList.add("alert-danger");
+        connectionStatus.classList.remove("green","lighten-4");
+        connectionStatus.classList.add("red","lighten-4");
     }
     
 }

--- a/src/files/www/dashboard/settings.html
+++ b/src/files/www/dashboard/settings.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <title>Step 4</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
     <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/settings.js" defer></script>
@@ -19,7 +19,7 @@
         <!-- Button container with border -->
         <div class="row button-container justify-content-between mt-3 align-items-center">
             <div class="col-auto">
-                <a id="back-btn-href" href="dashboard.html" class="btn btn-light">
+                <a id="back-btn-href" href="dashboard.html" class="btn grey lighten-3 black-text">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                         class="bi bi-arrow-bar-left" viewBox="0 0 16 16">
                         <path fill-rule="evenodd"
@@ -32,7 +32,7 @@
                 <h6 class="mb-0">Device Settings</h6>
             </div>
             <div class="col-auto">
-                <a href="dashboard.html" class="btn btn-link">Dashboard</a>
+                <a href="dashboard.html" class="btn-flat">Dashboard</a>
                 </a>
             </div>
         </div>
@@ -56,11 +56,11 @@
                     <div class="form-text">Chose secure password</div>
                 </div>
                 <div class="d-flex col-auto text-center justify-content-center pb-4 pt-1">
-                    <button type="button" class="btn btn-success mt-4" id="wifi-update">Update</button>
+                    <button type="button" class="btn green mt-4" id="wifi-update">Update</button>
                 </div>
             </div>
             <div class="row">
-                <a name="Advance Settings" id="" class="btn btn-link" href="../../cgi-bin/luci/" role="button">Advance
+                <a name="Advance Settings" id="" class="btn-flat" href="../../cgi-bin/luci/" role="button">Advance
                     Settings</a>
             </div>
 
@@ -79,10 +79,6 @@
         </div>
     </div>
 
-    <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-        <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000"
-            style="width: 100%">
-            <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
         </div>
     </div>
 </body>

--- a/src/files/www/dashboard/styles/style.css
+++ b/src/files/www/dashboard/styles/style.css
@@ -45,3 +45,21 @@ body {
   :dir(rtl) {
     font-family: 'Vazirmatn', sans-serif;
   }
+
+.spinner-border {
+    border: 4px solid rgba(0,0,0,0.1);
+    border-left-color: transparent;
+    border-radius: 50%;
+    width: 3rem;
+    height: 3rem;
+    animation: spin 0.75s linear infinite;
+}
+
+.spinner-border.text-light {
+    border-color: rgba(255,255,255,0.2);
+    border-left-color: #fff;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}

--- a/src/files/www/dashboard/vpn.html
+++ b/src/files/www/dashboard/vpn.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Step 3</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
     <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/vpn.js" defer></script>
@@ -17,7 +17,7 @@
         <!-- Button container with border -->
         <div class="row button-container justify-content-between mt-3 align-items-center">
             <div class="col-auto">
-                <a id="back-btn-href" href="ethernet.html" class="btn btn-light">
+                <a id="back-btn-href" href="ethernet.html" class="btn grey lighten-3 black-text">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-left" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M12.5 15a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5M10 8a.5.5 0 0 1-.5.5H3.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L3.707 7.5H9.5a.5.5 0 0 1 .5.5"/>
                     </svg>
@@ -28,8 +28,8 @@
                 <h6 class="mb-0">Step 3: VPN Connection</h6>
             </div>
             <div class="col-auto">
-                <a href="dashboard.html" class="btn btn-link">Dashboard</a>
-                <a href="guest.html" class="btn btn-light">Next 
+                <a href="dashboard.html" class="btn-flat">Dashboard</a>
+                <a href="guest.html" class="btn grey lighten-3 black-text">Next 
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-right" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M6 8a.5.5 0 0 0 .5.5h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L12.293 7.5H6.5A.5.5 0 0 0 6 8m-2.5 7a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5"/>
                 </svg>
@@ -41,8 +41,7 @@
         <div class="row justify-content-center mt-3">
             
             <!-- Note -->
-            <div class="alert alert-info alert-dismissible fade show mx-1" role="alert" >
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
+            <div class="card-panel blue lighten-4 mx-1" role="alert" >
                 <div>
                     In this step, we configure the VPN. Using a VPN is necessary to hide the IP address of your autonomous internet source (e.g., Starlink). In this step, Split Tunneling will also be automatically configured, which separates domestic and international IP traffic. Please be patient while following the instructions in this step!
                 </div>
@@ -53,7 +52,7 @@
             </div>
             
             <!-- How to  -->
-            <div class="row alert alert-light mx-1" role="alert">
+            <div class="row card-panel grey lighten-5 mx-1" role="alert">
                 <strong>Instruction:</strong>
                 <div class="col-auto">
                     <ul>
@@ -91,7 +90,7 @@
             </div>
             
             <div class="col-auto text-center" >
-                <button class="btn btn-outline-light px-4 py-3 mt-2" id="get-config">
+                <button class="btn btn-flat px-4 py-3 mt-2" id="get-config">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-arrow-down" viewBox="0 0 16 16">
                         <path d="M8.5 6.5a.5.5 0 0 0-1 0v3.793L6.354 9.146a.5.5 0 1 0-.708.708l2 2a.5.5 0 0 0 .708 0l2-2a.5.5 0 0 0-.708-.708L8.5 10.293z"/>
                         <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2M9.5 3A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5z"/>
@@ -104,7 +103,7 @@
 
         <div id="vpn-part" class="d-flex row container justify-content-center align-items-center py-3 ">
             <div class="row" style="max-width: 180px;">
-                <button class="btn btn-outline-danger px-2 py-1 my-3" id="change-config" >
+                <button class="btn btn-flat red-text px-2 py-1 my-3" id="change-config" >
                     Change Config
                 </button>
             </div>
@@ -155,9 +154,9 @@
         </div>
         <!-- Warning -->
         <div id="warning-part" class="row container justify-content-start mt-3">
-            <div class="alert alert-warning text-start d-none" id="english-alert" role="alert">
+            <div class="card-panel yellow lighten-4 text-start d-none" id="english-alert" role="alert">
                 <div class="position-absolute top-0 end-0" style="margin-top: 3px; margin-right: 3px;">
-                    <button id="fa-btn" class="btn btn-outline-light btn-sm" for="fa-btn">فارسی</button>
+                    <button id="fa-btn" class="btn btn-flat btn-sm" for="fa-btn">فارسی</button>
                 </div>
 
                 <h5 class="alert-heading mb-1 text-center">Warning!</h5>
@@ -171,9 +170,9 @@
                 </ol>
             </div>
 
-            <div dir="rtl" class="alert alert-warning text-end" id="farsi-alert" role="alert">
+            <div dir="rtl" class="card-panel yellow lighten-4 text-end" id="farsi-alert" role="alert">
                 <div class="position-absolute top-0 end-0" style="margin-top: 3px; margin-right: 3px;">
-                    <button id="en-btn" type="button" class="btn btn-outline-light btn-sm">English</button>
+                    <button id="en-btn" type="button" class="btn btn-flat btn-sm">English</button>
                 </div>
 
                 <h5 class="alert-heading mb-1 text-center">هشدار</h5>
@@ -201,9 +200,6 @@
         </div>
     </div> 
  
-    <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-        <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" style="width: 100%">
-            <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
         </div>
     </div>
 </body>

--- a/src/files/www/dashboard/wifi.html
+++ b/src/files/www/dashboard/wifi.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Step 1</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles/bootstrap.min.css">
+    <link rel='stylesheet' href='materialize/materialize.min.css'>
+    <script type='text/javascript' src='materialize/materialize.min.js' defer></script>
     <link rel="stylesheet" href="styles/style.css">
-    <script type="text/javascript" src="scripts/common/bootstrap.bundle.min.js" defer></script>
     <script type="text/javascript" src="scripts/common/loading.js" defer></script>
     <script type="text/javascript" src="scripts/common/ubus.js" defer></script>
     <script type="text/javascript" src="scripts/page-specific/wifi.js" defer></script>
@@ -17,7 +17,7 @@
         <!-- Button container with border -->
         <div class="row button-container justify-content-between mt-3 align-items-center">
             <div class="col-auto">
-                <a id="back-btn-href" href="index.html" class="btn btn-light">
+                <a id="back-btn-href" href="index.html" class="btn grey lighten-3 black-text">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-left" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M12.5 15a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5M10 8a.5.5 0 0 1-.5.5H3.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L3.707 7.5H9.5a.5.5 0 0 1 .5.5"/>
                     </svg>
@@ -28,8 +28,8 @@
                 <h6 class="mb-0">Step 1:<br> Connect NeighborLink to Global Internet</h6>
             </div>
             <div class="col-auto">
-                <a href="dashboard.html" class="btn btn-link">Dashboard</a>
-                <a href="ethernet.html" class="btn btn-light">Next 
+                <a href="dashboard.html" class="btn-flat">Dashboard</a>
+                <a href="ethernet.html" class="btn grey lighten-3 black-text">Next 
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-bar-right" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M6 8a.5.5 0 0 0 .5.5h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L12.293 7.5H6.5A.5.5 0 0 0 6 8m-2.5 7a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5"/>
                 </svg>
@@ -41,8 +41,7 @@
         <div class="row justify-content-center mt-3">
             
             <!-- Note -->
-            <div class="alert alert-info alert-dismissible fade show mx-1" role="alert" >
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
+            <div class="card-panel blue lighten-4 mx-1" role="alert" >
                 <div>
                     We recommend using an Ethernet cable to connect to the NeighborLink Router for the setup process. If you use Wi-Fi, you may need to reconnect multiple times, increasing the likelihood of errors during the setup process.
                 </div>
@@ -53,7 +52,7 @@
             </div>
             
             <!-- How to  -->
-            <div class="row alert alert-light mx-1" role="alert">
+            <div class="row card-panel grey lighten-5 mx-1" role="alert">
                 <strong>Instruction:</strong>
                 <div class="col-auto">
                     <ul>
@@ -75,7 +74,7 @@
 
         <div class="row container justify-content-center align-items-center mb-3">
             <div id="elements-parent-container" class="col-12 col-lg-6  col-md-6 border border-secoundry py-3 px-4">
-                <div id="connection-status" class="row alert alert-danger justify-content-center align-items-center">
+                <div id="connection-status" class="row card-panel red lighten-4 justify-content-center align-items-center">
                     <div class="col text-start">
                         <strong>Status: Disconnected</strong>
                     </div>
@@ -85,7 +84,7 @@
                 </div>
                 <div class="row button-container justify-content-center align-items-center">
                     
-                    <button class="btn btn-success internet-source-global-wifi w-75 px-4 py-3" id="scan-wifi-btn">
+                    <button class="btn green internet-source-global-wifi w-75 px-4 py-3" id="scan-wifi-btn">
                         <svg viewBox="0 0 1024 1024" class="dashboard-icon17" width="24" fill="#fff">
                             <path d="M214 554q124-122 299-122t297 122l-84 86q-36-36-99-62t-115-26-115 26-99 62zM384 726q54-54 128-54t128 54l-128 128zM42 384q196-194 471-194t469 194l-86 86q-160-158-384-158t-384 158z"></path>
                         </svg>
@@ -144,10 +143,10 @@
             </div>
             <div class="row d-flex justify-content-center mt-4">
                 <div class="col text-center">
-                    <button type="button" class="btn btn-outline-light " id="cancel">Cancel</button>
+                    <button type="button" class="btn btn-flat " id="cancel">Cancel</button>
                 </div>
                 <div class="col text-center">
-                    <button type="button" class="btn btn-success " id="connect">Connect</button>
+                    <button type="button" class="btn green " id="connect">Connect</button>
                 </div>
                 
             </div>
@@ -166,9 +165,6 @@
         </div>
     </div> 
  
-    <div class="toast-container position-fixed  top-0 start-0 text-center" style="width: 100%;">
-        <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="3000" style="width: 100%">
-            <div class="alert alert-danger m-0" role="alert">You're not connected to router!</div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- drop bootstrap imports from dashboard HTML files
- include Materialize CSS/JS instead
- replace bootstrap classes with Materialize equivalents
- use Materialize toast and modal APIs in JS
- add simple spinner styles

## Testing
- `node config-generator/index.test.js`

------
https://chatgpt.com/codex/tasks/task_b_685fb62e44a0832fa44d5242a12b5a68