### PR TITLE
Add centralized process logging

### DIFF
--- a/src/files/etc/init.d/chisel
+++ b/src/files/etc/init.d/chisel
@@ -7,13 +7,29 @@ USE_PROCD=1
 START=90
 STOP=90
 LOGFILE="/var/log/chisel.log"
+PROCESS_LOG="/var/log/chisel_process.log"
+
+init_process_log() {
+    [ -f "$PROCESS_LOG" ] || { touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"; }
+    if [ $(stat -c%s "$PROCESS_LOG" 2>/dev/null || echo 0) -gt 1000000 ]; then
+        mv "$PROCESS_LOG" "$PROCESS_LOG.1" 2>/dev/null
+        touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"
+    fi
+}
+
+log_msg() {
+    init_process_log
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $1" >> "$PROCESS_LOG"
+}
 
 start_service() {
 
+    log_msg "Checking chisel service configuration"
     # Retrieve configuration from UCI
     ENABLED=$(uci get routro.ireach.enabled)
         if [ "$ENABLED" == "0" ];then
                 echo "Connect -  Service is disabled." >> $LOGFILE
+                log_msg "Service is disabled"
                 exit 0
         fi
 
@@ -27,9 +43,11 @@ start_service() {
     if [ -z "$key" ] || [ -z "$port" ] || [ -z "$host" ] || [ -z "$proxyport" ] || [ -z "$password" ]; then
         echo "chisel_status=MISSING_CONFIG" > /tmp/chisel_status
         echo "Service is not ready. Missing configuration."
+        log_msg "Missing configuration, aborting start"
         exit 0
     fi
 
+    log_msg "Starting chisel service"
     # Initialize procd instance
     procd_open_instance
 
@@ -41,10 +59,12 @@ start_service() {
 
     # Close the procd instance
     procd_close_instance
+    log_msg "chisel service started"
 }
 
 stop() {
     echo "Connect - Stopping chisel service" >> $LOGFILE
+    log_msg "Stopping chisel service"
     # Commands to stop/kill the application
     # killall chisel 2>/dev/null
 }

--- a/src/files/etc/init.d/outlineGate
+++ b/src/files/etc/init.d/outlineGate
@@ -7,10 +7,25 @@ USE_PROCD=1
 START=96
 STOP=96
 LOGFILE="/var/log/outline-gate.log"
+PROCESS_LOG="/var/log/chisel_process.log"
+
+init_process_log() {
+    [ -f "$PROCESS_LOG" ] || { touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"; }
+    if [ $(stat -c%s "$PROCESS_LOG" 2>/dev/null || echo 0) -gt 1000000 ]; then
+        mv "$PROCESS_LOG" "$PROCESS_LOG.1" 2>/dev/null
+        touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"
+    fi
+}
+
+log_msg() {
+    init_process_log
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $1" >> "$PROCESS_LOG"
+}
 
 
 start_service() {
 
+        log_msg "Starting outlineGate service"
         key=$(uci get routro.ireach.user)
         port=$(uci get routro.ireach.port)
         host=$(uci get routro.ireach.host)
@@ -25,6 +40,7 @@ start_service() {
         if [ -z "$key" ] || [ -z "$port" ] || [ -z "$host" ] || [ -z "$password" ]  || [ -z "$mport" ] || [ -z "$oport" ] || [ -z "$ohost" ];then
                 echo "outlineGate_status=MISSINF_CONFIG" > /tmp/outlineGate_status
                 echo "Connect - service is not ready" >> $LOGFILE
+                log_msg "Missing configuration, aborting start"
                 exit 0;
         fi
 
@@ -37,10 +53,12 @@ start_service() {
         procd_set_param stdout 1
         procd_set_param stderr 1
         procd_close_instance
+        log_msg "outlineGate service started"
 }
 
 stop() {
 
         echo "Connect - Stopping outlinegate service" >> $LOGFILE
+        log_msg "Stopping outlineGate service"
         # commands to kill application
 }

--- a/src/files/usr/bin/check_chisel.sh
+++ b/src/files/usr/bin/check_chisel.sh
@@ -2,14 +2,32 @@
 
 
 LOGFILE=/var/log/chisel.log
+PROCESS_LOG="/var/log/chisel_process.log"
+
+init_process_log() {
+    [ -f "$PROCESS_LOG" ] || { touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"; }
+    if [ $(stat -c%s "$PROCESS_LOG" 2>/dev/null || echo 0) -gt 1000000 ]; then
+        mv "$PROCESS_LOG" "$PROCESS_LOG.1" 2>/dev/null
+        touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"
+    fi
+}
+
+log_msg() {
+    init_process_log
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $1" >> "$PROCESS_LOG"
+}
 
 if [ "$1" == "outline" ];then
     LOGFILE=/var/log/outline-gate.log
 fi
 
+# Indicate detection check
+log_msg "Checking status from $LOGFILE"
+
 # Exit early if the log file hasn't been created yet
 if [ ! -f "$LOGFILE" ]; then
     echo "unknown"
+    log_msg "Log file $LOGFILE missing"
     exit 0
 fi
 
@@ -32,3 +50,4 @@ while IFS= read -r line; do
 done < <(grep -i "Connect" $LOGFILE)
 
 echo "$last_status"
+log_msg "Status result: $last_status"

--- a/src/files/usr/bin/dragon.sh
+++ b/src/files/usr/bin/dragon.sh
@@ -1,5 +1,21 @@
 #!/bin/sh
 # this script will work as a api gateway
+PROCESS_LOG="/var/log/chisel_process.log"
+
+init_process_log() {
+    [ -f "$PROCESS_LOG" ] || { touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"; }
+    if [ $(stat -c%s "$PROCESS_LOG" 2>/dev/null || echo 0) -gt 1000000 ]; then
+        mv "$PROCESS_LOG" "$PROCESS_LOG.1" 2>/dev/null
+        touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"
+    fi
+}
+
+log_msg() {
+    init_process_log
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $1" >> "$PROCESS_LOG"
+}
+
+log_msg "dragon.sh called with $*"
 response() {
     echo "<___RESPONSE___>"
     echo -e "$1"
@@ -105,21 +121,25 @@ if [ "$1" == "ifconfig" ];then
 fi
 
 if [ "$1" == "ip-api" ];then
+    log_msg "Executing ip-api"
     RESULT=$(curl -s ip-api.com/json?fields=status,message,country,isp,query)
     response "$RESULT"
 fi
 
 if [ "$1" == "vpn-on" ];then
+    log_msg "Enabling VPN"
     RESULT=$(sh /usr/bin/wg_scripts.sh on)
     response "$RESULT"
 fi
 
 if [ "$1" == "vpn-off" ];then
+    log_msg "Disabling VPN"
     RESULT=$(sh /usr/bin/wg_scripts.sh off)
     response "$RESULT"
 fi
 
 if [ "$1" == "guest-on" ];then
+    log_msg "Enabling guest wifi"
     uci set wireless.guest_2g.disabled="0"
     uci set wireless.guest_5g.disabled="0"
     uci commit wireless
@@ -130,6 +150,8 @@ fi
 
 if [ "$1" == "guest-off" ];then
 
+    log_msg "Disabling guest wifi"
+
     uci set wireless.guest_2g.disabled="1"
     uci set wireless.guest_5g.disabled="1"
     uci commit wireless
@@ -139,6 +161,7 @@ if [ "$1" == "guest-off" ];then
 fi
 
 if [ "$1" == "guest-set" ];then
+    log_msg "Setting guest wifi"
     ssid=$2
     pass=$3
     if [ -z "$1" ] || [ -z "$2" ] ; then
@@ -173,6 +196,7 @@ if [ "$1" == "wifi-set" ];then
 fi
 
 if [ "$1" == "infinite-reach-connect" ];then
+    log_msg "Infinite Reach connect"
 
     if [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ] || [ -z "$5" ] || [ -z "$6" ] || [ -z "$7" ] || [ -z "$8" ] || [ -z "$9" ]; then
         response "Missing_Info"
@@ -213,6 +237,7 @@ if [ "$1" == "infinite-reach-connect" ];then
 fi
 
 if [ "$1" == "infinite-reach-disconnect" ];then
+    log_msg "Infinite Reach disconnect"
 
     uci set routro.ireach.enabled='0'
     uci commit routro
@@ -235,6 +260,7 @@ if [ "$1" == "infinite-reach-disconnect" ];then
 fi
 
 if [ "$1" == "infinite-reach-status" ];then
+    log_msg "Infinite Reach status"
     iReach_HOST=$(uci get routro.ireach.host)
     iREACH_EN=$(uci get routro.ireach.enabled)
     tPROXY_EN=$(uci get tinyproxy.@tinyproxy[0].enabled)
@@ -262,6 +288,7 @@ if [ "$1" == "ireach-proxy-get" ];then
 fi
 
 if [ "$1" == "ireach-enable" ];then
+    log_msg "ireach enable"
     /etc/init.d/tinyproxy start
     /etc/init.d/tinyproxy enable
     sleep 2
@@ -269,6 +296,7 @@ if [ "$1" == "ireach-enable" ];then
 fi
 
 if [ "$1" == "ireach-disable" ];then
+    log_msg "ireach disable"
     /etc/init.d/tinyproxy stop
     /etc/init.d/tinyproxy disable
     sleep 2
@@ -276,6 +304,7 @@ if [ "$1" == "ireach-disable" ];then
 fi
 
 if [ "$1" == "ireach-regen" ];then
+    log_msg "ireach regen"
     /etc/init.d/tinyproxy stop
     RANDOMPASS=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 10)
     USER=iReach$(hexdump -n 2 -e '/2 "%u"' /dev/urandom)
@@ -287,6 +316,7 @@ if [ "$1" == "ireach-regen" ];then
 fi
 
 if [ "$1" == "ireach-outline-get" ];then
+    log_msg "outline get"
     STATUS=$(/etc/init.d/outlineGate status)
     if [ -z "$STATUS" ] ; then
         STATUS="null"
@@ -299,6 +329,7 @@ if [ "$1" == "ireach-outline-get" ];then
 fi
 
 if [ "$1" == "ireach-outline-set" ];then
+    log_msg "outline set"
     host=$2
     port=$3
     if [ -z "$1" ] || [ -z "$2" ] ; then
@@ -327,18 +358,21 @@ if [ "$1" == "ireach-outline-set" ];then
 fi
 
 if [ "$1" == "ireach-outline-write" ];then
+    log_msg "outline write"
     uci set routro.outlinegate.savedKey="$2"
     uci commit routro
     response "Done"
 fi
 
 if [ "$1" == "wireguard-set-conf" ];then
+    log_msg "wireguard set conf"
     config_base64=$2
     echo "$config_base64" | base64 -d > /peer.json
     response "Done"
 fi
 
 if [ "$1" = "monitor-log" ]; then
+    log_msg "monitor log $2"
     case "$2" in
         starlink) file="/var/log/starlink.log" ;;
         iran) file="/var/log/iran.log" ;;
@@ -354,16 +388,19 @@ if [ "$1" = "monitor-log" ]; then
 fi
 
 if [ "$1" = "user-stats" ]; then
+    log_msg "user stats"
     stats=$(sh /usr/bin/user_stats.sh)
     response "$stats"
 fi
 
 if [ "$1" = "user-online" ]; then
+    log_msg "user online"
     online=$(sh /usr/bin/online_users.sh)
     response "$online"
 fi
 
 if [ "$1" == "check-link" ];then
+    log_msg "check link"
     result=$(sh /usr/bin/check_link.sh "$2" "$3")
     response "$result"
 fi

--- a/src/files/usr/bin/proxymaster.sh
+++ b/src/files/usr/bin/proxymaster.sh
@@ -1,6 +1,21 @@
 #!/bin/sh
 # Define the file name and the URL to download from
 FILE="/tmp/chisel"
+# Log file for process events
+PROCESS_LOG="/var/log/chisel_process.log"
+
+init_process_log() {
+    [ -f "$PROCESS_LOG" ] || { touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"; }
+    if [ $(stat -c%s "$PROCESS_LOG" 2>/dev/null || echo 0) -gt 1000000 ]; then
+        mv "$PROCESS_LOG" "$PROCESS_LOG.1" 2>/dev/null
+        touch "$PROCESS_LOG" && chmod 600 "$PROCESS_LOG"
+    fi
+}
+
+log_msg() {
+    init_process_log
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $1" >> "$PROCESS_LOG"
+}
 # Determine architecture for chisel download
 ARCH_RAW=$(uname -m)
 case "$ARCH_RAW" in
@@ -37,6 +52,7 @@ case "$ARCH_RAW" in
         exit 1
         ;;
 esac
+log_msg "Detected architecture $ARCH for chisel"
 
 URL="https://holistic-config.s3.us-west-1.amazonaws.com/chisel/chisel_1.10.0_linux_${ARCH}_softfloat"
 
@@ -58,38 +74,46 @@ download_chisel() {
     attempts=0
     max_attempts=3
     while [ $attempts -lt $max_attempts ]; do
+        log_msg "Attempting to download chisel (try $((attempts+1)))"
         curl "$URL" -s -o "$FILE"
         code=$?
         if [ $code -ne 0 ]; then
             logger -t pmaster "Download failed with exit code $code"
+            log_msg "Download failed with exit code $code"
         elif file "$FILE" | grep -q "ELF"; then
             chmod +x "$FILE"
+            log_msg "Download succeeded"
             return 0
         else
             logger -t pmaster "Invalid binary downloaded, retrying"
+            log_msg "Invalid binary downloaded"
         fi
         rm -f "$FILE"
         attempts=$((attempts + 1))
         sleep 1
     done
+    log_msg "Download failed after $max_attempts attempts"
     return 1
 }
 
 # Check if the file exists
 if [ ! -f "$FILE" ]; then
-    download_chisel || { logger -t pmaster "Failed to obtain valid binary"; exit 1; }
+    log_msg "chisel binary not found"
+    download_chisel || { logger -t pmaster "Failed to obtain valid binary"; log_msg "Failed to obtain valid binary"; exit 1; }
     # Restart the chisel service
     /etc/init.d/chisel restart
     /etc/init.d/outlineGate restart
+    log_msg "Services restarted after download"
 else
     if [ $(stat -c %s /tmp/chisel) -gt 9500000 ]; then
         if ! pgrep chisel; then
             # Restart the chisel service
             /etc/init.d/chisel restart
             /etc/init.d/outlineGate restart
+            log_msg "Services restarted (chisel not running)"
         fi
     else
         rm /tmp/chisel
-        download_chisel || { logger -t pmaster "Failed to obtain valid binary"; exit 1; }
+        download_chisel || { logger -t pmaster "Failed to obtain valid binary"; log_msg "Failed to obtain valid binary"; exit 1; }
     fi
 fi


### PR DESCRIPTION
## Summary
- add `PROCESS_LOG` var for common process logging
- record actions in init scripts and helper scripts
- rotate the process log when it exceeds 1MB

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686078f061dc832facccd28bf5e45185