### PR TITLE
Fix chisel build in firmware build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The `src/build.bash` script fetches the OpenWrt SDK and now also compiles the
 builder, run:
 
 ```
-GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -ldflags="-s -w" -o ../files/usr/bin/chisel github.com/jpillora/chisel
+GOOS=linux GOARCH=mipsle GOMIPS=softfloat go install -ldflags="-s -w" github.com/jpillora/chisel@latest
+cp $(go env GOPATH)/bin/linux_mipsle/chisel src/files/usr/bin/chisel
 ```
 
 The compiled binary is stored in `src/files/usr/bin/chisel` and will be

--- a/src/build.bash
+++ b/src/build.bash
@@ -60,7 +60,8 @@ for profile in $profiles; do
   tar -J -x -f openwrt-imagebuilder-"$PATH_PART".Linux-x86_64.tar.xz 2>/dev/null > /dev/null
 
   # Build chisel for routers
-  GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -ldflags="-s -w" -o ../files/usr/bin/chisel github.com/jpillora/chisel
+  GOOS=linux GOARCH=mipsle GOMIPS=softfloat go install -ldflags="-s -w" github.com/jpillora/chisel@latest
+  cp "$(go env GOPATH)/bin/linux_mipsle/chisel" ../files/usr/bin/chisel
 
   sed -i "s/option version .*/option version '$release_version'/" "files/etc/config/routro"
   sed -i "s/option profile .*/option profile '$profile'/" "files/etc/config/routro"


### PR DESCRIPTION
## Summary
- update README instructions to compile chisel with `go install`
- fix `src/build.bash` to use `go install` and copy resulting binary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861a83dbd2c832faf13753f2c383247