### PR TITLE
Add Go setup for firmware build

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -32,9 +32,15 @@ jobs:
             gawk git gettext libssl-dev xsltproc rsync unzip \
             python3 python3-distutils jq
 
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
       - name: Build the Firmware
         if: github.event_name != 'release'
         run: |
+          export PATH="$(go env GOPATH)/bin:$PATH"
           cd src
           bash build.bash ${GITHUB_SHA::6} ${{ matrix.profile }}
 
@@ -48,6 +54,7 @@ jobs:
       - name: Build the Firmware (Release)
         if: github.event_name == 'release'
         run: |
+          export PATH="$(go env GOPATH)/bin:$PATH"
           cd src
           bash build.bash ${{ github.event.release.tag_name }} ${{ matrix.profile }}
 


### PR DESCRIPTION
## Summary
- install Go in firmware workflow so `go` is available
- include Go binaries in PATH while building

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861ad22b7b0832f8fd37047688372c8