### PR TITLE
Add strict mode to Iran server scripts

### DIFF
--- a/server/Iran_server/update_panel.sh
+++ b/server/Iran_server/update_panel.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Network interface to monitor. Can be overridden by setting the NL_INTERFACE
 # environment variable before running this script.

--- a/server/Iran_server/uploader_filler.sh
+++ b/server/Iran_server/uploader_filler.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # This helper script attempts to keep upstream and downstream bandwidth usage
 # closer together by sending dummy data when inbound traffic greatly exceeds

--- a/server/Iran_server/watch_vnstat.sh
+++ b/server/Iran_server/watch_vnstat.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
 # Network interface to monitor. Can be overridden by setting the NL_INTERFACE
 # environment variable before running this script.
 INTERFACE="${NL_INTERFACE:-eth0}"
 
-watch -n60 "vnstat -i $INTERFACE --oneline | awk -F';' '{print \$3 \" \$4 \" (rx↔tx)\"}'"
+watch -n60 "vnstat -i \"$INTERFACE\" --oneline | awk -F';' '{print \$3 \" \$4 \" (rx↔tx)\"}'"


### PR DESCRIPTION
## Summary
- turn on `set -euo pipefail` for Iran server shell scripts
- tighten quoting in the watch script
- improve error handling in setup script
- use `read -r` to avoid unwanted escapes

## Testing
- `npm test --prefix config-generator`
- `npm test --prefix server/chisel_config_manager` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686235a21800832f99e309390d45e2e3