### PR TITLE
Fix build artifacts tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 ramips/
 TODO
 src/openwrt-imagebuilder*
-src/build/*.bin
+src/build/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ included in the generated firmware images. When this binary exists on the
 router, the init scripts use it directly and skip downloading Chisel at run
 time.
 
+To build the firmware images themselves, run the build script with a
+version label and the desired router profile:
+
+```
+cd src
+./build.bash <VERSION> <PROFILE>
+```
+
+All generated `.bin` files are written to `src/build/`. This directory is
+ignored by Git so the firmware artifacts are produced during each build
+instead of being stored in the repository.
+
 ## User Management Enhancements
 Users can limit the number of devices per account using the **Max Devices** field and optionally set a comma separated list of permitted MAC addresses. A helper script `user_stats.sh` prints traffic usage per user based on firewall counters. Stale MAC entries are purged whenever a login occurs so the limit only counts active devices.
 The management page table now lists these values beside each username so administrators can quickly review configured limits.


### PR DESCRIPTION
## Summary
- ignore the entire firmware output directory
- document how to run the build script to produce firmware images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6862478ba1fc832f86f451a89c798f89