### PR TITLE
Enable SSH on first reboot

### DIFF
--- a/src/files/etc/rc.local
+++ b/src/files/etc/rc.local
@@ -247,7 +247,8 @@ chmod +x /www/portal/auth.lua
 /etc/init.d/tinyproxy disable
 
 /etc/init.d/uhttpd restart
-/etc/init.d/dropbear restart 
+/etc/init.d/dropbear enable
+/etc/init.d/dropbear restart
 
 rm -f /etc/rc.local
 reboot


### PR DESCRIPTION
## Summary
- ensure Dropbear is enabled so SSH starts on subsequent reboots

## Testing
- `bash -n src/files/etc/rc.local`

------
https://chatgpt.com/codex/tasks/task_b_686fcc4af3a8832f8a7ad7da8d33b795