### PR TITLE
Bundle chisel binary in firmware build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,8 @@ cp $(go env GOPATH)/bin/linux_mipsle/chisel build/chisel-linux-mipsle
 ```
 
 The compiled binary is stored in `src/build/chisel-linux-mipsle` alongside the
-generated firmware images. It is **not** bundled into the firmware itself.
-After flashing OpenWrt, copy this binary to the router and make it executable:
-
-```
-scp build/chisel-linux-mipsle root@<router-ip>:/usr/bin/chisel
-ssh root@<router-ip> "chmod +x /usr/bin/chisel"
-```
+generated firmware images and is now bundled into the firmware at
+`/usr/bin/chisel` with executable permissions already set.
 
 Once installed, restart the Chisel-related services so they pick up the binary
 location:

--- a/src/build.bash
+++ b/src/build.bash
@@ -63,6 +63,10 @@ for profile in $profiles; do
   GOOS=linux GOARCH=mipsle GOMIPS=softfloat go install -ldflags="-s -w" github.com/jpillora/chisel@latest
   mkdir -p "$BUILD_DIR"
   cp "$(go env GOPATH)/bin/linux_mipsle/chisel" "$BUILD_DIR/chisel-linux-mipsle"
+  # Bundle chisel into the firmware
+  mkdir -p "$FILES/usr/bin"
+  cp "$BUILD_DIR/chisel-linux-mipsle" "$FILES/usr/bin/chisel"
+  chmod +x "$FILES/usr/bin/chisel"
 
   sed -i "s/option version .*/option version '$release_version'/" "files/etc/config/routro"
   sed -i "s/option profile .*/option profile '$profile'/" "files/etc/config/routro"


### PR DESCRIPTION
## Summary
- copy the compiled chisel binary into `files/usr/bin/chisel`
- make the file executable during the build
- update README to mention that chisel is now included in the firmware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686fcbaa2908832fa59d58b26ff2b8e0