### PR TITLE
Fix build dir path for reused ImageBuilder

### DIFF
--- a/src/build.bash
+++ b/src/build.bash
@@ -5,6 +5,10 @@
 
 set -e
 
+# Determine the absolute path to this script directory so all other
+# paths remain valid even when we change directories later on.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 #Openwrt Version
 wrt_version="23.05.2"
 
@@ -28,9 +32,9 @@ EXCLUDE_PACKAGES='-dnsmasq -wpad-basic-mbedtls'
 # Included Packages
 INCLUDE_PACKAGES='curl dnsmasq-full luci luci-base iwinfo wireguard-tools kmod-nft-core kmod-nft-fib kmod-nft-nat kmod-nft-offload mtd ubus ubusd rpcd rpcd-mod-file rpcd-mod-iwinfo uci uhttpd uhttpd-mod-ubus gnupg tinyproxy jq coreutils-stat coreutils-nohup lua luasocket uhttpd-mod-lua coreutils-base64 wpad-openssl pbr kmod-br-netfilter kmod-ipt-physdev iptables-mod-physdev'
 
-FILES="../files"
+FILES="$SCRIPT_DIR/files"
 
-BUILD_DIR="build"
+BUILD_DIR="$SCRIPT_DIR/build"
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 
@@ -85,12 +89,12 @@ for profile in $profiles; do
   cp "$BUILD_DIR/chisel-linux-mipsle" "$FILES/usr/bin/chisel"
   chmod +x "$FILES/usr/bin/chisel"
 
-  sed -i "s/option version .*/option version '$release_version'/" "files/etc/config/routro"
-  sed -i "s/option profile .*/option profile '$profile'/" "files/etc/config/routro"
+  sed -i "s/option version .*/option version '$release_version'/" "$FILES/etc/config/routro"
+  sed -i "s/option profile .*/option profile '$profile'/" "$FILES/etc/config/routro"
   
     # Check and copy profile-specific network config if it exists
-  if [ -f "files/etc/config/network.d/$profile.conf" ]; then
-    cp "files/etc/config/network.d/$profile.conf" "files/etc/config/network"
+  if [ -f "$FILES/etc/config/network.d/$profile.conf" ]; then
+    cp "$FILES/etc/config/network.d/$profile.conf" "$FILES/etc/config/network"
   fi
   
   cd "$IMAGEBUILDER_REPO"
@@ -105,7 +109,7 @@ for profile in $profiles; do
 
     newname=$(echo "$file" | sed " s|openwrt-$PATH_PART-$profile-|$profile-$release_version-| " )
 
-    newfile=../$BUILD_DIR/$(basename "$newname")
+    newfile="$BUILD_DIR/$(basename "$newname")"
     echo "$newfile:"
     # Rename the file
     mv "$file" "$newfile"


### PR DESCRIPTION
## Summary
- make paths absolute in `build.bash`

## Testing
- `bash -n src/build.bash`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686fe39332b8832f8ff7cce122c4304a