### PR TITLE
Enable dropbear password login

### DIFF
--- a/src/files/etc/rc.local
+++ b/src/files/etc/rc.local
@@ -207,8 +207,8 @@ sed -i 's|cgi-bin/luci|lua-bin/dashboard|g' /www/index.html
 #################################################################################
 #-------------< sshkey
 #################################################################################
-uci set dropbear.@dropbear[0].PasswordAuth='off'
-uci set dropbear.@dropbear[0].RootPasswordAuth='off'
+uci set dropbear.@dropbear[0].PasswordAuth='on'
+uci set dropbear.@dropbear[0].RootPasswordAuth='on'
 chmod 600 /etc/dropbear/authorized_keys 
 #--------------------------------------
 


### PR DESCRIPTION
## Summary
- allow password logins via dropbear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686fe8f9d31c832f819cc8dc7b780c48