### PR TITLE
Add GeoIP blocklist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Users can limit the number of devices per account using the **Max Devices** fiel
 The management page table now lists these values beside each username so administrators can quickly review configured limits.
 Another helper script `online_users.sh` reports how many devices are currently connected for each user by checking the router's ARP table. The dashboard displays this "Online" count next to the configured maximum.
 
+## GeoIP Blocklists
+The weekly cron job `update_geoip.sh` updates the policy based routing rules using
+Iranian IP ranges. To prevent certain addresses from ever traversing the Starlink
+link, add them to `/etc/geoip/blocklist.list` (one address or CIDR per line).
+Entries from this file are always appended to the GeoIP data based on the routing
+`mode` (either `default`, `cidr` or `off`). Even with GeoIP disabled (`off`),
+the blocklist entries are enforced so traffic to those destinations is routed
+through the local `wan` interface instead of Starlink.
+
 ## Monitoring Panel and Dummy Traffic
 A simple monitoring panel shows VNStat bandwidth statistics, including a TX/RX ratio updated every minute by `update_panel.sh`. By default both `update_panel.sh` and the helper script `watch_vnstat.sh` monitor the `eth0` interface, but you can override this by setting the `NL_INTERFACE` environment variable so the TX/RX ratio reflects the correct device. To help keep the ratio reasonable, the helper script `uploader_filler.sh` may upload random data to [transfer.sh](https://transfer.sh) when received traffic greatly exceeds transmitted traffic.
 `uploader_filler.sh` now stores the previous receive and transmit counters in `/var/tmp/uploader_filler_state`. If this file is missing, the current counters are recorded and the script exits without uploading. On subsequent runs it compares the difference in RX and TX bytes since the last invocation and only performs an upload when 80% of the received bytes is still greater than the transmitted bytes. The current counters are always written back to the state file so the next run can determine the delta. The script also respects `NL_INTERFACE` so you can monitor any interface.

--- a/src/files/etc/geoip/blocklist.list
+++ b/src/files/etc/geoip/blocklist.list
@@ -1,0 +1,1 @@
+# Place IP ranges or addresses to route via wan

--- a/src/files/usr/bin/update_geoip.sh
+++ b/src/files/usr/bin/update_geoip.sh
@@ -6,6 +6,7 @@ CACHE_DIR="/etc/geoip"
 CIDR_FILE="$CACHE_DIR/IR.cidr"
 IPV6_FILE="$CACHE_DIR/IR.ipv6"
 DEFAULT_FILE="$CACHE_DIR/IR_default.list"
+BLOCKLIST_FILE="$CACHE_DIR/blocklist.list"
 
 mkdir -p "$CACHE_DIR"
 
@@ -13,25 +14,25 @@ MODE=$(uci -q get routro.routing.mode 2>/dev/null)
 
 [ -z "$MODE" ] && MODE="default"
 
-if [ "$MODE" = "off" ]; then
-    uci set pbr.@policy[0].enabled='0'
-    uci delete pbr.@policy[0].dest_addr 2>/dev/null
-    uci commit pbr
-    /etc/init.d/pbr restart
-    exit 0
-fi
+dest_addr=""
 
 if [ "$MODE" = "cidr" ]; then
     /usr/bin/curl -fsSL "$CIDR_URL" -o "$CIDR_FILE" && \
     dest_addr=$(grep -v '^#' "$CIDR_FILE" | tr '\n' ' ')
     /usr/bin/curl -fsSL "$IPV6_URL" -o "$IPV6_FILE" >/dev/null 2>&1
-else
+elif [ "$MODE" = "default" ]; then
     [ -f "$DEFAULT_FILE" ] && dest_addr=$(cat "$DEFAULT_FILE")
 fi
+
+[ -f "$BLOCKLIST_FILE" ] && block_addr=$(grep -v '^#' "$BLOCKLIST_FILE" | tr '\n' ' ')
+[ -n "$block_addr" ] && dest_addr="$dest_addr $block_addr"
 
 if [ -n "$dest_addr" ]; then
     uci set pbr.@policy[0].dest_addr="$dest_addr"
     uci set pbr.@policy[0].enabled='1'
-    uci commit pbr
-    /etc/init.d/pbr restart
+else
+    uci set pbr.@policy[0].enabled='0'
+    uci delete pbr.@policy[0].dest_addr 2>/dev/null
 fi
+uci commit pbr
+/etc/init.d/pbr restart


### PR DESCRIPTION
## Summary
- support custom GeoIP blocklist in `update_geoip.sh`
- include example `/etc/geoip/blocklist.list`
- document usage in README
- enforce blocklist even when GeoIP mode is `off`

## Testing
- `bash -n src/files/usr/bin/update_geoip.sh`


------
https://chatgpt.com/codex/tasks/task_b_68710d958a68832f9f720b3d954e9087