### PR TITLE
Add kill switch controls

### DIFF
--- a/src/files/etc/config/routro
+++ b/src/files/etc/config/routro
@@ -39,3 +39,6 @@ config ireach 'ireach'
     
 config routing 'routing'
     option mode 'default'
+
+config settings 'settings'
+    option killswitch '1'

--- a/src/files/usr/bin/dragon.sh
+++ b/src/files/usr/bin/dragon.sh
@@ -138,6 +138,29 @@ if [ "$1" == "vpn-off" ];then
     response "$RESULT"
 fi
 
+if [ "$1" == "killswitch-on" ];then
+    log_msg "Enabling kill switch"
+    uci set routro.settings.killswitch='1'
+    uci commit routro
+    /usr/bin/vpn_killswitch.sh block
+    response "Done"
+fi
+
+if [ "$1" == "killswitch-off" ];then
+    log_msg "Disabling kill switch"
+    uci set routro.settings.killswitch='0'
+    uci commit routro
+    /usr/bin/vpn_killswitch.sh unblock
+    response "Done"
+fi
+
+if [ "$1" == "killswitch-status" ];then
+    log_msg "Kill switch status"
+    STATUS=$(uci get routro.settings.killswitch 2>/dev/null)
+    [ -z "$STATUS" ] && STATUS="1"
+    response "$STATUS"
+fi
+
 if [ "$1" == "guest-on" ];then
     log_msg "Enabling guest wifi"
     uci set wireless.guest_2g.disabled="0"

--- a/src/files/usr/bin/link_monitor.sh
+++ b/src/files/usr/bin/link_monitor.sh
@@ -28,12 +28,14 @@ check_iface(){
 
 check_vpn(){
     status=$(sh /usr/bin/wg_scripts.sh status)
+    ks=$(uci get routro.settings.killswitch 2>/dev/null)
+    [ -z "$ks" ] && ks="1"
     if echo "$status" | grep '__Connected__' >/dev/null 2>&1; then
         echo "$(date +"%F %T") [vpn] OK" >> "$VPN_LOG"
-        /usr/bin/vpn_killswitch.sh unblock
+        [ "$ks" = "1" ] && /usr/bin/vpn_killswitch.sh unblock
     else
         echo "$(date +"%F %T") [vpn] FAIL" >> "$VPN_LOG"
-        /usr/bin/vpn_killswitch.sh block
+        [ "$ks" = "1" ] && /usr/bin/vpn_killswitch.sh block
     fi
     tail -n 1000 "$VPN_LOG" > "$VPN_LOG.tmp" && mv "$VPN_LOG.tmp" "$VPN_LOG"
 }

--- a/src/files/www/dashboard/dashboard.html
+++ b/src/files/www/dashboard/dashboard.html
@@ -156,8 +156,18 @@
                                 <div id="ip-address" class="text-info-emphasis">0.0.0.0</div>
                             </div>
                             <div class="col">
-                                <div id="internet-provider" class="text-info-emphasis">Checking... </div>
+                            <div id="internet-provider" class="text-info-emphasis">Checking... </div>
                             </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mt-2">
+                    <div class="col">Kill Switch:</div>
+                    <div class="col">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="kill-switch-enable">
+                            <label class="form-check-label" for="kill-switch-enable" id="kill-switch-enable-label">Disable</label>
                         </div>
                     </div>
                 </div>

--- a/src/files/www/dashboard/scripts/page-specific/dashboard.js
+++ b/src/files/www/dashboard/scripts/page-specific/dashboard.js
@@ -4,6 +4,8 @@ const vpnStauts = document.getElementById("connection-status")
 const vpnShield = document.getElementById("vpn-shield")
 const ipAddress = document.getElementById("ip-address")
 const internetProvider = document.getElementById("internet-provider")
+const killSwitchEnable = document.getElementById('kill-switch-enable')
+const killSwitchLabel = document.getElementById('kill-switch-enable-label')
 
 const btnStarlink = document.getElementById('starlink-btn')
 const btnIran = document.getElementById('iran-btn')
@@ -258,6 +260,41 @@ async function getConfig(){
         updateReach("disable")
     }
 }
+
+killSwitchEnable.onclick = async function(e){
+    setKillSwitchStatus(killSwitchEnable.checked)
+    if(killSwitchEnable.checked){
+        loading(true,"Enabling kill switch")
+        await async_lua_call("dragon.sh","killswitch-on")
+    }else{
+        loading(true,"Disabling kill switch")
+        await async_lua_call("dragon.sh","killswitch-off")
+    }
+    await readKillSwitchStatus()
+}
+
+function setKillSwitchStatus(status){
+    if(status){
+        killSwitchLabel.textContent = "Enable"
+        killSwitchEnable.checked = true
+    }else{
+        killSwitchLabel.textContent = "Disable"
+        killSwitchEnable.checked = false
+    }
+}
+
+async function readKillSwitchStatus(){
+    const KS_STAT=["file","exec",{"command":"dragon.sh","params":[ "killswitch-status" ]}];
+    var response=await async_ubus_call(KS_STAT)
+    const stdout = response[1].stdout
+    if(stdout.includes('0')){
+        setKillSwitchStatus(false)
+    }else{
+        setKillSwitchStatus(true)
+    }
+}
+
+readKillSwitchStatus()
 
 document.getElementById('en-btn').addEventListener('click', function() {
     document.getElementById('english-alert').classList.remove('d-none');


### PR DESCRIPTION
## Summary
- add kill switch config to routro
- support kill switch management in dragon.sh
- update link monitor to honor kill switch setting
- expose toggle in dashboard UI

## Testing
- `node --version`
- `bash -n src/files/usr/bin/dragon.sh`
- `bash -n src/files/usr/bin/link_monitor.sh`


------
https://chatgpt.com/codex/tasks/task_b_68711beae1e0832f81e990877bc853c7