### PR TITLE
Move kill switch option to settings page

### DIFF
--- a/src/files/www/dashboard/dashboard.html
+++ b/src/files/www/dashboard/dashboard.html
@@ -162,15 +162,7 @@
                     </div>
                 </div>
 
-                <div class="row mt-2">
-                    <div class="col">Kill Switch:</div>
-                    <div class="col">
-                        <div class="form-check form-switch">
-                            <input class="form-check-input" type="checkbox" role="switch" id="kill-switch-enable">
-                            <label class="form-check-label" for="kill-switch-enable" id="kill-switch-enable-label">Disable</label>
-                        </div>
-                    </div>
-                </div>
+
 
                 <!-- Warning -->
                 <div id="warning-part" class="row container justify-content-start mt-3">

--- a/src/files/www/dashboard/scripts/page-specific/dashboard.js
+++ b/src/files/www/dashboard/scripts/page-specific/dashboard.js
@@ -4,8 +4,6 @@ const vpnStauts = document.getElementById("connection-status")
 const vpnShield = document.getElementById("vpn-shield")
 const ipAddress = document.getElementById("ip-address")
 const internetProvider = document.getElementById("internet-provider")
-const killSwitchEnable = document.getElementById('kill-switch-enable')
-const killSwitchLabel = document.getElementById('kill-switch-enable-label')
 
 const btnStarlink = document.getElementById('starlink-btn')
 const btnIran = document.getElementById('iran-btn')
@@ -261,40 +259,6 @@ async function getConfig(){
     }
 }
 
-killSwitchEnable.onclick = async function(e){
-    setKillSwitchStatus(killSwitchEnable.checked)
-    if(killSwitchEnable.checked){
-        loading(true,"Enabling kill switch")
-        await async_lua_call("dragon.sh","killswitch-on")
-    }else{
-        loading(true,"Disabling kill switch")
-        await async_lua_call("dragon.sh","killswitch-off")
-    }
-    await readKillSwitchStatus()
-}
-
-function setKillSwitchStatus(status){
-    if(status){
-        killSwitchLabel.textContent = "Enable"
-        killSwitchEnable.checked = true
-    }else{
-        killSwitchLabel.textContent = "Disable"
-        killSwitchEnable.checked = false
-    }
-}
-
-async function readKillSwitchStatus(){
-    const KS_STAT=["file","exec",{"command":"dragon.sh","params":[ "killswitch-status" ]}];
-    var response=await async_ubus_call(KS_STAT)
-    const stdout = response[1].stdout
-    if(stdout.includes('0')){
-        setKillSwitchStatus(false)
-    }else{
-        setKillSwitchStatus(true)
-    }
-}
-
-readKillSwitchStatus()
 
 document.getElementById('en-btn').addEventListener('click', function() {
     document.getElementById('english-alert').classList.remove('d-none');

--- a/src/files/www/dashboard/scripts/page-specific/settings.js
+++ b/src/files/www/dashboard/scripts/page-specific/settings.js
@@ -2,6 +2,8 @@ var guestSsid = document.getElementById('wifi-ssid');
 var guestPassword = document.getElementById('wifi-password');
 var guestUpdate = document.getElementById('wifi-update');
 var routingModeSelect = document.getElementById('routing-mode');
+var killSwitchEnable = document.getElementById('kill-switch-enable');
+var killSwitchLabel = document.getElementById('kill-switch-enable-label');
 
 
 function validateSSID(ssid) {
@@ -79,3 +81,38 @@ routingModeSelect.onchange = async function(e){
     var mode = routingModeSelect.value;
     await async_lua_call("dragon.sh","routing-mode "+mode);
 }
+
+killSwitchEnable.onclick = async function(e){
+    setKillSwitchStatus(killSwitchEnable.checked)
+    if(killSwitchEnable.checked){
+        loading(true,"Enabling kill switch")
+        await async_lua_call("dragon.sh","killswitch-on")
+    }else{
+        loading(true,"Disabling kill switch")
+        await async_lua_call("dragon.sh","killswitch-off")
+    }
+    await readKillSwitchStatus()
+}
+
+function setKillSwitchStatus(status){
+    if(status){
+        killSwitchLabel.textContent = "Enable"
+        killSwitchEnable.checked = true
+    }else{
+        killSwitchLabel.textContent = "Disable"
+        killSwitchEnable.checked = false
+    }
+}
+
+async function readKillSwitchStatus(){
+    const KS_STAT=["file","exec",{"command":"dragon.sh","params":[ "killswitch-status" ]}];
+    var response=await async_ubus_call(KS_STAT)
+    const stdout = response[1].stdout
+    if(stdout.includes('0')){
+        setKillSwitchStatus(false)
+    }else{
+        setKillSwitchStatus(true)
+    }
+}
+
+readKillSwitchStatus()

--- a/src/files/www/dashboard/settings.html
+++ b/src/files/www/dashboard/settings.html
@@ -59,20 +59,29 @@
                     <button type="button" class="btn btn-success mt-4" id="wifi-update">Update</button>
                 </div>
             </div>
-            <div class="row mt-2">
-                <div class="col-auto">
-                    <label for="routing-mode" class="form-label">Routing Mode</label>
-                    <select id="routing-mode" class="form-select">
-                        <option value="off">Disabled</option>
-                        <option value="default">Default IP List</option>
-                        <option value="cidr">CIDR IP List</option>
-                    </select>
+                <div class="row mt-2">
+                    <div class="col-auto">
+                        <label for="routing-mode" class="form-label">Routing Mode</label>
+                        <select id="routing-mode" class="form-select">
+                            <option value="off">Disabled</option>
+                            <option value="default">Default IP List</option>
+                            <option value="cidr">CIDR IP List</option>
+                        </select>
+                    </div>
                 </div>
-            </div>
-            <div class="row">
-                <a name="Advance Settings" id="" class="btn btn-link" href="../../cgi-bin/luci/" role="button">Advance
-                    Settings</a>
-            </div>
+                <div class="row mt-2">
+                    <div class="col">Kill Switch:</div>
+                    <div class="col">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="kill-switch-enable">
+                            <label class="form-check-label" for="kill-switch-enable" id="kill-switch-enable-label">Disable</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <a name="Advance Settings" id="" class="btn btn-link" href="../../cgi-bin/luci/" role="button">Advance
+                        Settings</a>
+                </div>
 
 
         </div>


### PR DESCRIPTION
## Summary
- relocate kill switch UI from dashboard to settings page
- update settings JavaScript to handle kill switch operations
- remove kill switch code from dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6871245e97d0832fb949cfb3108b24de