### PR TITLE
Add log size display and clear feature

### DIFF
--- a/src/files/usr/bin/dragon.sh
+++ b/src/files/usr/bin/dragon.sh
@@ -410,6 +410,38 @@ if [ "$1" = "monitor-log" ]; then
     fi
 fi
 
+if [ "$1" = "log-size" ]; then
+    log_msg "log size $2"
+    case "$2" in
+        starlink) file="/var/log/starlink.log" ;;
+        iran) file="/var/log/iran.log" ;;
+        vpn) file="/var/log/vpn.log" ;;
+        citylink) file="/var/log/citylink.log" ;;
+        *) file="/var/log/link-monitor.log" ;;
+    esac
+    if [ -f "$file" ]; then
+        size=$(stat -c%s "$file" 2>/dev/null || echo 0)
+        response "$size"
+    else
+        response "0"
+    fi
+fi
+
+if [ "$1" = "clear-log" ]; then
+    log_msg "clear log $2"
+    case "$2" in
+        starlink) file="/var/log/starlink.log" ;;
+        iran) file="/var/log/iran.log" ;;
+        vpn) file="/var/log/vpn.log" ;;
+        citylink) file="/var/log/citylink.log" ;;
+        *) file="/var/log/link-monitor.log" ;;
+    esac
+    if [ -f "$file" ]; then
+        : > "$file"
+    fi
+    response "ok"
+fi
+
 if [ "$1" = "user-stats" ]; then
     log_msg "user stats"
     stats=$(sh /usr/bin/user_stats.sh)

--- a/src/files/www/dashboard/logs.html
+++ b/src/files/www/dashboard/logs.html
@@ -22,6 +22,10 @@
     </div>
     <h6 id="log-title" class="mb-2">Starlink Log</h6>
     <pre id="log-content" class="bg-body-secondary p-2" style="height:60vh; overflow:auto;"></pre>
+    <div class="d-flex justify-content-between align-items-center mt-2">
+        <small>Size: <span id="log-size">0 B</span></small>
+        <button id="clear-log" class="btn btn-danger btn-sm">Clear Log</button>
+    </div>
 </div>
 <div id="overlay" class="display=none flex-column align-items-center mb-3">
     <div class="spinner-border text-light mb-2" role="status">

--- a/src/files/www/dashboard/scripts/page-specific/logs.js
+++ b/src/files/www/dashboard/scripts/page-specific/logs.js
@@ -1,8 +1,27 @@
 const container = document.getElementById('log-content');
 const title = document.getElementById('log-title');
 const buttons = document.querySelectorAll('[data-type]');
+const logSize = document.getElementById('log-size');
+const clearBtn = document.getElementById('clear-log');
+let currentType = 'starlink';
+
+function formatBytes(bytes){
+    if(!bytes) return '0 B';
+    const sizes=['B','KB','MB','GB'];
+    const i=Math.floor(Math.log(bytes)/Math.log(1024));
+    return (bytes/Math.pow(1024,i)).toFixed(1)+' '+sizes[i];
+}
+
+function updateLogSize(type){
+    const CMD=["file","exec",{"command":"dragon.sh","params":["log-size", type]}];
+    return async_ubus_call(CMD).then(res=>{
+        const bytes=parseInt(res[1].stdout||'0');
+        if(logSize) logSize.textContent=formatBytes(bytes);
+    });
+}
 
 function loadLogs(type){
+    currentType = type;
     loading(true, 'Loading logs');
     const CMD=["file","exec",{"command":"dragon.sh","params":["monitor-log", type]}];
     async_ubus_call(CMD).then(res => {
@@ -12,6 +31,7 @@ function loadLogs(type){
             const label = type.charAt(0).toUpperCase() + type.slice(1);
             title.textContent = `${label} Log`;
         }
+        updateLogSize(type);
         loading(false);
     });
 }
@@ -19,6 +39,15 @@ function loadLogs(type){
 buttons.forEach(btn => {
     btn.addEventListener('click', () => loadLogs(btn.dataset.type));
 });
+
+if(clearBtn){
+    clearBtn.addEventListener('click', () => {
+        if(confirm('Clear current log?')){
+            const CMD=["file","exec",{"command":"dragon.sh","params":["clear-log", currentType]}];
+            async_ubus_call(CMD).then(()=>loadLogs(currentType));
+        }
+    });
+}
 
 document.addEventListener('DOMContentLoaded', () => {
     loadLogs('starlink');


### PR DESCRIPTION
## Summary
- show log sizes and a button to clear logs
- implement `log-size` and `clear-log` actions in `dragon.sh`
- update JS to call new actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68712485dfe0832f8f2787714ae291f9