### PR TITLE
Fix kill switch enable loader

### DIFF
--- a/src/files/www/dashboard/scripts/page-specific/dashboard.js
+++ b/src/files/www/dashboard/scripts/page-specific/dashboard.js
@@ -292,6 +292,7 @@ async function readKillSwitchStatus(){
     }else{
         setKillSwitchStatus(true)
     }
+    loading(false)
 }
 
 readKillSwitchStatus()


### PR DESCRIPTION
## Summary
- fix infinite loading after enabling kill switch by hiding overlay when status is read

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6871246a2cf8832f81ead921477c07e7