### PR TITLE
Add Guest access block UI toggle

### DIFF
--- a/src/files/etc/config/firewall
+++ b/src/files/etc/config/firewall
@@ -89,13 +89,14 @@ config rule
         option target 'ACCEPT'                
 
                      
-config rule
+config rule 'guest_mgmt_block'
     option name 'Block Guest Access to Management Interface'
-    option src 'guest_zone'                                      
+    option src 'guest_zone'
     option dest_ip '192.168.0.0/16'  # Specify the router's management IP
     option dest_port '80'
-    option proto 'tcp'                    
+    option proto 'tcp'
     option target 'REJECT'
+    option enabled '1'
 
 config rule                                   
         option name 'Drop_Guest_Traffic'   

--- a/src/files/usr/bin/dragon.sh
+++ b/src/files/usr/bin/dragon.sh
@@ -201,6 +201,29 @@ if [ "$1" == "guest-set" ];then
     response "Done"
 fi
 
+if [ "$1" == "guest-mgmt-block-on" ];then
+    log_msg "Blocking guest access to management interface"
+    uci set firewall.guest_mgmt_block.enabled='1'
+    uci commit firewall
+    /etc/init.d/firewall reload
+    response "Done"
+fi
+
+if [ "$1" == "guest-mgmt-block-off" ];then
+    log_msg "Allowing guest access to management interface"
+    uci set firewall.guest_mgmt_block.enabled='0'
+    uci commit firewall
+    /etc/init.d/firewall reload
+    response "Done"
+fi
+
+if [ "$1" == "guest-mgmt-block-status" ];then
+    log_msg "Guest management block status"
+    STATUS=$(uci get firewall.guest_mgmt_block.enabled 2>/dev/null)
+    [ -z "$STATUS" ] && STATUS="1"
+    response "$STATUS"
+fi
+
 if [ "$1" == "wifi-set" ];then
     ssid=$2
     pass=$3

--- a/src/files/www/dashboard/scripts/page-specific/settings.js
+++ b/src/files/www/dashboard/scripts/page-specific/settings.js
@@ -5,6 +5,8 @@ var routingModeSelect = document.getElementById('routing-mode');
 
 const killSwitchEnable = document.getElementById('kill-switch-enable');
 const killSwitchLabel = document.getElementById('kill-switch-enable-label');
+const guestBlockEnable = document.getElementById('guest-block-enable');
+const guestBlockLabel = document.getElementById('guest-block-enable-label');
 
 
 
@@ -98,6 +100,42 @@ killSwitchEnable.onclick = async function(e){
 
 }
 
+guestBlockEnable.onclick = async function(e){
+    setGuestBlockStatus(guestBlockEnable.checked)
+    if(guestBlockEnable.checked){
+        loading(true,"Blocking guest access")
+        await async_lua_call("dragon.sh","guest-mgmt-block-on")
+    }else{
+        loading(true,"Allowing guest access")
+        await async_lua_call("dragon.sh","guest-mgmt-block-off")
+    }
+    await readGuestBlockStatus()
+    loading(false)
+
+}
+
+function setGuestBlockStatus(status){
+    if(status){
+        guestBlockLabel.textContent = "Enable";
+        guestBlockEnable.checked = true;
+    }else{
+        guestBlockLabel.textContent = "Disable";
+        guestBlockEnable.checked = false;
+    }
+}
+
+async function readGuestBlockStatus(){
+    const GB_STAT=["file","exec",{"command":"dragon.sh","params":[ "guest-mgmt-block-status" ]}];
+    var response=await async_ubus_call(GB_STAT);
+    const stdout = response[1].stdout;
+    if(stdout.includes('0')){
+        setGuestBlockStatus(false);
+    }else{
+        setGuestBlockStatus(true);
+    }
+    loading(false);
+}
+
 function setKillSwitchStatus(status){
     if(status){
         killSwitchLabel.textContent = "Enable";
@@ -121,3 +159,4 @@ async function readKillSwitchStatus(){
 }
 
 readKillSwitchStatus();
+readGuestBlockStatus();

--- a/src/files/www/dashboard/settings.html
+++ b/src/files/www/dashboard/settings.html
@@ -83,6 +83,20 @@
                         <small class="text-muted">The kill switch blocks Starlink traffic if the VPN disconnects.</small>
                     </div>
                 </div>
+                <div class="row mt-2">
+                    <div class="col">Block Guest Access:</div>
+                    <div class="col">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="guest-block-enable">
+                            <label class="form-check-label" for="guest-block-enable" id="guest-block-enable-label">Disable</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col">
+                        <small class="text-muted">Prevent guest network from accessing this dashboard.</small>
+                    </div>
+                </div>
 
             </div>
             <div class="row">


### PR DESCRIPTION
## Summary
- allow toggling firewall rule to block guest network access to the management interface
- expose new commands in `dragon.sh` to modify firewall rule
- add checkbox in settings page to toggle the rule
- update JS to handle new switch and fetch status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6871813eedec832f8a62a97cfd296b0f